### PR TITLE
fix: Tool improvements, bug fixes, and validated examples

### DIFF
--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -2,7 +2,7 @@
 
 This example demonstrates a complete HFSS microstrip patch antenna workflow
 using the pyaedt-mcp tools. All steps below were validated live against
-ANSYS AEDT 2025 R2.
+ANSYS AEDT 2025 R2 on April 20, 2026.
 
 ## 1. Check AEDT Installation
 
@@ -19,13 +19,19 @@ Response:
 
 **Tool:** `launch_aedt`
 
+| Parameter      | Value |
+|----------------|-------|
+| non_graphical  | false |
+
+> Launch in graphical mode so the antenna and S11 report are visible in the GUI.
+
 ```
 Response:
   Successfully launched AEDT Desktop
   Version: 2025.2
-  gRPC Port: 57993
-  PID: 11712
-  Startup Time: ~6s
+  gRPC Port: 59661
+  PID: 2600
+  Startup Time: ~18s
 ```
 
 ## 3. Create HFSS Design
@@ -41,7 +47,7 @@ Response:
 Response:
   Successfully created Hfss design
   Design Name: PatchAntenna_Validation
-  Project: Project2
+  Project: Project6
   Solution Type: Terminal
 ```
 
@@ -89,7 +95,58 @@ result = "Geometry and boundaries created. Objects: {}".format(objects)
 Response: Geometry and boundaries created. Objects: ['Substrate', 'Ground', 'Patch']
 ```
 
-## 5. Create Setup and Frequency Sweep
+## 5. Add Feed Line, Lumped Port, and Air Box
+
+**Tool:** `run_python_code`
+
+```python
+from ansys.aedt.core import Hfss
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+
+# Feed line (3mm wide, centered in X, from y=0 to patch edge at y=8mm)
+feed_x = (40 - 3) / 2
+feed = hfss.modeler.create_rectangle(
+    orientation="XY",
+    origin=["{:.1f}mm".format(feed_x), "0mm", "1.6mm"],
+    sizes=["3mm", "8mm"],
+    name="FeedLine"
+)
+hfss.assign_perfecte_to_sheets(feed.name)
+
+# Feed port face (YZ plane at y=0, spans ground to feedline)
+feed_port = hfss.modeler.create_rectangle(
+    orientation="YZ",
+    origin=["{:.1f}mm".format(feed_x), "0mm", "0mm"],
+    sizes=["1.6mm", "3mm"],
+    name="FeedPort"
+)
+
+# Lumped port with Ground reference
+hfss.lumped_port(
+    assignment="FeedPort",
+    name="Port1",
+    reference=["Ground"],
+    integration_line=1
+)
+
+# Air box + radiation boundary
+airbox = hfss.modeler.create_box(
+    origin=["-15mm", "-15mm", "-15mm"],
+    sizes=["70mm", "70mm", "31.6mm"],
+    name="AirBox",
+    material="vacuum"
+)
+hfss.assign_radiation_boundary_to_objects("AirBox")
+
+objects = [obj.name for obj in hfss.modeler.objects.values()]
+result = "Feed, port, and airbox added. Objects: {}".format(objects)
+```
+
+```
+Response: Feed, port, and airbox added. Objects: ['FeedLine', 'Substrate', 'Ground', 'Patch', 'FeedPort', 'AirBox']
+```
+
+## 6. Create Setup and Frequency Sweep
 
 **Tool:** `run_python_code`
 
@@ -114,63 +171,132 @@ sweep = hfss.create_linear_step_sweep(
     name="Sweep1"
 )
 
-result = "Setup and sweep created. Setup: {}, Sweep: Sweep1".format(setup.name)
+# Validate design
+valid = hfss.validate_full_design()
+
+result = "Setup and sweep created. Setup: {}, Sweep: Sweep1, Valid: {}".format(
+    setup.name, valid[1] if isinstance(valid, tuple) else valid
+)
 ```
 
 ```
-Response: Setup and sweep created. Setup: Setup1, Sweep: Sweep1
+Response: Setup and sweep created. Setup: Setup1, Sweep: Sweep1, Valid: True
 ```
 
-## 6. Capture Screenshot
+## 7. Capture Pre-Solve Screenshot
 
 **Tool:** `screenshot`
 
-Returns a PNG image of the current AEDT 3D viewport.
+Returns a PNG image of the AEDT viewport showing the antenna geometry.
 
-## 7. Get Model Info
+## 8. Solve the Design
 
-**Tool:** `get_model_info`
+**Tool:** `run_python_code`
 
-| Parameter   | Value                     |
-|-------------|---------------------------|
-| design_name | PatchAntenna_Validation   |
+```python
+import time
+from ansys.aedt.core import Hfss
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
 
-```json
-{
-  "design_name": "PatchAntenna_Validation",
-  "design_type": "HFSS",
-  "project_path": "..."
-}
+hfss.save_project()
+t0 = time.time()
+solved = hfss.analyze()
+elapsed = time.time() - t0
+
+result = "Solved: {}, Time: {:.0f}s".format(solved, elapsed)
 ```
 
-## 8. List Projects / Designs
-
-**Tool:** `list_projects`
-
-```json
-{ "open_projects": ["Project2"], "count": 1 }
+```
+Response: Solved: True, Time: 81s
 ```
 
-**Tool:** `list_designs`
+## 9. Create S11 Report and Export Results
 
-```json
-{ "project": "Project2", "designs": ["PatchAntenna_Validation"], "count": 1 }
+**Tool:** `run_python_code`
+
+> Terminal solution type uses `St()` notation (not `S()`).
+
+```python
+import os, math
+from ansys.aedt.core import Hfss
+
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+
+# Create S11 report via native API
+report_module = hfss.odesign.GetModule("ReportSetup")
+report_module.CreateReport(
+    "S11_Return_Loss",
+    "Terminal Solution Data",
+    "Rectangular Plot",
+    "Setup1 : Sweep1",
+    ["Domain:=", "Sweep"],
+    ["Freq:=", ["All"]],
+    ["X Component:=", "Freq", "Y Component:=", ["dB(St(Port1_T1,Port1_T1))"]]
+)
+
+# Export Touchstone for data analysis
+snp_path = r"D:\ANSYS-DEV\screenshots\PatchAntenna_Validation.s1p"
+os.makedirs(os.path.dirname(snp_path), exist_ok=True)
+hfss.export_touchstone(setup="Setup1", sweep="Sweep1", output_file=snp_path)
+
+# Parse S1P (MA format: freq_GHz magnitude angle_deg)
+with open(snp_path, 'r') as f:
+    lines = f.readlines()
+data = [l.strip() for l in lines if l.strip() and not l.startswith('!') and not l.startswith('#')]
+min_s11, min_freq = 999, 0
+for line in data:
+    parts = line.split()
+    if len(parts) >= 3:
+        freq, mag = float(parts[0]), float(parts[1])
+        db = 20 * math.log10(mag) if mag > 0 else -100
+        if db < min_s11:
+            min_s11, min_freq = db, freq
+
+# Export report image
+jpg_path = r"D:\ANSYS-DEV\screenshots\S11_Report_Validation.jpg"
+report_module.ExportImageToFile("S11_Return_Loss", jpg_path, 1920, 1080)
+
+result = "S11 Report created! Resonance: {:.4f} GHz, S11 = {:.2f} dB".format(min_freq, min_s11)
 ```
 
-## 9. Export 3D Model
-
-**Tool:** `export_3d_model`
-
-| Parameter     | Value                  |
-|---------------|------------------------|
-| output_path   | D:/output/model.step   |
-| export_format | step                   |
-
 ```
-Response: 3D model exported to: D:/output/model.step (12345 bytes, format: step)
+Response: S11 Report created! Resonance: 2.8000 GHz, S11 = -5.22 dB
 ```
 
-## 10. Clear AEDT
+## 10. Capture Post-Solve Screenshot
+
+**Tool:** `screenshot`
+
+Returns a PNG showing the S11_Return_Loss report visible in the AEDT GUI.
+
+## 11. Export 3D Model
+
+**Tool:** `run_python_code`
+
+```python
+import os
+from ansys.aedt.core import Hfss
+
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+
+step_path = r"D:\ANSYS-DEV\screenshots\PatchAntenna_Validation.step"
+export_ok = hfss.export_3d_model(
+    file_name="PatchAntenna_Validation",
+    file_path=r"D:\ANSYS-DEV\screenshots",
+    file_format=".step"
+)
+hfss.save_project()
+
+result = "STEP export: {}, size: {} bytes".format(
+    export_ok, os.path.getsize(step_path) if os.path.exists(step_path) else 0
+)
+```
+
+```
+Response: STEP export: True, size: 30257 bytes
+```
+
+## 12. Clear AEDT (Optional)
 
 **Tool:** `clear_aedt`
 

--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -1,0 +1,179 @@
+# HFSS Patch Antenna Workflow
+
+This example demonstrates a complete HFSS microstrip patch antenna workflow
+using the pyaedt-mcp tools. All steps below were validated live against
+ANSYS AEDT 2025 R2.
+
+## 1. Check AEDT Installation
+
+**Tool:** `check_aedt_installed`
+
+```
+Response:
+  AEDT is installed on this system.
+  Version: 2025.2
+  Executable: C:\Program Files\ANSYS Inc\v252\AnsysEM\ansysedt.exe
+```
+
+## 2. Launch AEDT
+
+**Tool:** `launch_aedt`
+
+```
+Response:
+  Successfully launched AEDT Desktop
+  Version: 2025.2
+  gRPC Port: 57993
+  PID: 11712
+  Startup Time: ~6s
+```
+
+## 3. Create HFSS Design
+
+**Tool:** `create_design`
+
+| Parameter   | Value                     |
+|-------------|---------------------------|
+| app_type    | Hfss                      |
+| design_name | PatchAntenna_Validation   |
+
+```
+Response:
+  Successfully created Hfss design
+  Design Name: PatchAntenna_Validation
+  Project: Project2
+  Solution Type: Terminal
+```
+
+## 4. Build Geometry and Boundaries
+
+**Tool:** `run_python_code`
+
+```python
+from ansys.aedt.core import Hfss
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+
+# Create substrate (40x40x1.6 mm FR4)
+substrate = hfss.modeler.create_box(
+    origin=[0, 0, 0],
+    sizes=["40mm", "40mm", "1.6mm"],
+    name="Substrate",
+    material="FR4_epoxy"
+)
+
+# Create ground plane
+ground = hfss.modeler.create_rectangle(
+    orientation="XY",
+    origin=[0, 0, 0],
+    sizes=["40mm", "40mm"],
+    name="Ground"
+)
+
+# Create patch (24x24 mm centered on substrate)
+patch = hfss.modeler.create_rectangle(
+    orientation="XY",
+    origin=["8mm", "8mm", "1.6mm"],
+    sizes=["24mm", "24mm"],
+    name="Patch"
+)
+
+# Assign PerfE boundaries
+hfss.assign_perfecte_to_sheets(ground.name)
+hfss.assign_perfecte_to_sheets(patch.name)
+
+objects = [obj.name for obj in hfss.modeler.objects.values()]
+result = "Geometry and boundaries created. Objects: {}".format(objects)
+```
+
+```
+Response: Geometry and boundaries created. Objects: ['Substrate', 'Ground', 'Patch']
+```
+
+## 5. Create Setup and Frequency Sweep
+
+**Tool:** `run_python_code`
+
+```python
+from ansys.aedt.core import Hfss
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+
+# Create setup at 2.4 GHz
+setup = hfss.create_setup(name="Setup1")
+setup.props["Frequency"] = "2.4GHz"
+setup.props["MaximumPasses"] = 6
+setup.props["MaxDeltaS"] = 0.02
+setup.update()
+
+# Add linear step sweep 1-4 GHz
+sweep = hfss.create_linear_step_sweep(
+    setup="Setup1",
+    unit="GHz",
+    start_frequency=1.0,
+    stop_frequency=4.0,
+    step_size=0.05,
+    name="Sweep1"
+)
+
+result = "Setup and sweep created. Setup: {}, Sweep: Sweep1".format(setup.name)
+```
+
+```
+Response: Setup and sweep created. Setup: Setup1, Sweep: Sweep1
+```
+
+## 6. Capture Screenshot
+
+**Tool:** `screenshot`
+
+Returns a PNG image of the current AEDT 3D viewport.
+
+## 7. Get Model Info
+
+**Tool:** `get_model_info`
+
+| Parameter   | Value                     |
+|-------------|---------------------------|
+| design_name | PatchAntenna_Validation   |
+
+```json
+{
+  "design_name": "PatchAntenna_Validation",
+  "design_type": "HFSS",
+  "project_path": "..."
+}
+```
+
+## 8. List Projects / Designs
+
+**Tool:** `list_projects`
+
+```json
+{ "open_projects": ["Project2"], "count": 1 }
+```
+
+**Tool:** `list_designs`
+
+```json
+{ "project": "Project2", "designs": ["PatchAntenna_Validation"], "count": 1 }
+```
+
+## 9. Export 3D Model
+
+**Tool:** `export_3d_model`
+
+| Parameter     | Value                  |
+|---------------|------------------------|
+| output_path   | D:/output/model.step   |
+| export_format | step                   |
+
+```
+Response: 3D model exported to: D:/output/model.step (12345 bytes, format: step)
+```
+
+## 10. Clear AEDT
+
+**Tool:** `clear_aedt`
+
+```
+Response: AEDT state cleared. Closed 1 project(s).
+```

--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -4,6 +4,10 @@ This example demonstrates a complete HFSS microstrip patch antenna workflow
 using the pyaedt-mcp tools. All steps below were validated live against
 ANSYS AEDT 2025 R2 on April 20, 2026.
 
+> **GUI Mode:** Launch AEDT with `non_graphical=false` so the GUI is visible
+> and you can see the antenna geometry, solved mesh, and S11 report plot
+> interactively in the AEDT window.
+
 ## 1. Check AEDT Installation
 
 **Tool:** `check_aedt_installed`

--- a/src/ansys/aedt/mcp/contexts.py
+++ b/src/ansys/aedt/mcp/contexts.py
@@ -206,8 +206,8 @@ setup.props["Frequency"] = "2.4GHz"
 hfss.create_linear_count_sweep(
     setup="Setup1",
     unit="GHz",
-    start=1,
-    stop=4,
+    start_frequency=1,
+    stop_frequency=4,
     num_of_freq_points=101
 )
 

--- a/src/ansys/aedt/mcp/helpers.py
+++ b/src/ansys/aedt/mcp/helpers.py
@@ -14,26 +14,12 @@ from ansys.common.mcp import get_logger
 logger = get_logger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Docker / container detection helpers
-# ---------------------------------------------------------------------------
-
-
 def _is_docker() -> bool:
-    """Detect whether the current process is running inside a Docker container.
-
-    Checks for ``/.dockerenv`` and ``/run/.containerenv`` marker files that
-    Docker and Podman create inside containers.
-
-    Returns
-    -------
-    bool
-        ``True`` when running inside a container, ``False`` otherwise.
-    """
+    """Detect whether the current process is running inside a Docker container."""
     return Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
 
 
-def _probe_grpc_endpoint(host: str, port: int, timeout: float = 2.0) -> bool:
+def _probe_grpc_endpoint(host: str, port: int, timeout: float = 2.0) -> dict[str, Any]:
     """Test whether a gRPC endpoint is reachable via a TCP connect probe.
 
     Parameters
@@ -47,14 +33,77 @@ def _probe_grpc_endpoint(host: str, port: int, timeout: float = 2.0) -> bool:
 
     Returns
     -------
-    bool
-        ``True`` if the TCP connection succeeded, ``False`` otherwise.
+    dict[str, Any]
+        ``{"reachable": bool, "host": str, "port": int, "error": str | None}``
     """
     try:
         with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except (OSError, ConnectionRefusedError, TimeoutError):
-        return False
+            return {"reachable": True, "host": host, "port": port, "error": None}
+    except Exception as e:
+        return {"reachable": False, "host": host, "port": port, "error": str(e)}
+
+
+def _resolve_aedt_executable(
+    version: str | None = None,
+) -> tuple[str, Path]:
+    """Resolve AEDT version and locate the executable.
+
+    Parameters
+    ----------
+    version : str | None
+        Requested version (e.g. ``"2025.2"``, ``"252"``).  ``None`` picks
+        the latest installed version.
+
+    Returns
+    -------
+    tuple[str, Path]
+        ``(target_version_key, path_to_ansysedt_exe)``
+
+    Raises
+    ------
+    RuntimeError
+        If no AEDT installation is found or the requested version is
+        unavailable.
+    """
+    from ansys.aedt.core.desktop import Desktop
+
+    temp = Desktop.__new__(Desktop)
+    available = getattr(temp, "installed_versions", {})
+    if not available:
+        raise RuntimeError("No AEDT versions found installed on this system.")
+
+    # Filter AWP root entries (not valid version IDs)
+    versions = {k: v for k, v in available.items() if not k.endswith("AWP")}
+    if not versions:
+        versions = available
+
+    # Resolve requested version
+    if version:
+        target = version
+        install_dir = versions.get(target)
+        if install_dir is None:
+            for v, path in versions.items():
+                if version in v or v in version:
+                    target, install_dir = v, path
+                    break
+        if install_dir is None:
+            raise RuntimeError(
+                f"AEDT version '{version}' not found. Available: {list(versions.keys())}"
+            )
+    else:
+        target = list(versions.keys())[-1]
+        install_dir = versions[target]
+
+    # Locate executable
+    exe_name = "ansysedt.exe" if os.name == "nt" else "ansysedt"
+    for candidate in [
+        Path(install_dir) / exe_name,
+        Path(install_dir) / "AnsysEM" / exe_name,
+    ]:
+        if candidate.exists():
+            return target, candidate
+
+    raise RuntimeError(f"AEDT executable not found under: {install_dir}")
 
 
 def get_aedt_info(desktop: Any) -> dict[str, Any]:

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -836,7 +836,7 @@ def export_results(
 
         setup_kwargs = {}
         if setup_name is not None:
-            setup_kwargs["setup_name"] = setup_name
+            setup_kwargs["setup"] = setup_name
 
         if export_type == "touchstone":
             if not hasattr(app_instance, "export_touchstone"):
@@ -1138,9 +1138,9 @@ def export_touchstone(
 
         kwargs: dict[str, Any] = {"output_file": output_path}
         if setup_name:
-            kwargs["setup_name"] = setup_name
+            kwargs["setup"] = setup_name
         if solution_name:
-            kwargs["sweep_name"] = solution_name
+            kwargs["sweep"] = solution_name
 
         result = app_instance.export_touchstone(**kwargs)
 

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -712,7 +712,10 @@ def create_design(
 
         logger.info(f"Creating {app_type} design: {design_name}")
 
-        kwargs: dict[str, Any] = {}
+        kwargs: dict[str, Any] = {
+            "port": desktop.port,
+            "non_graphical": desktop.non_graphical,
+        }
         if design_name:
             kwargs["design"] = design_name
         if project_name:
@@ -720,7 +723,7 @@ def create_design(
         if solution_type:
             kwargs["solution_type"] = solution_type
 
-        # Create the application/design
+        # Create the application/design using the existing desktop connection
         app_instance = app_class(**kwargs)
 
         return (

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -774,7 +774,10 @@ def analyze_design(
 
         from ansys.aedt.core import get_pyaedt_app
 
-        app = get_pyaedt_app(design_name=design_name)
+        app = get_pyaedt_app(
+            design_name=design_name,
+            desktop=desktop,
+        )
 
         kwargs = {}
         if num_cores is not None:
@@ -829,7 +832,7 @@ def export_results(
 
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app()
+        app_instance = get_pyaedt_app(desktop=desktop)
 
         setup_kwargs = {}
         if setup_name is not None:
@@ -1041,25 +1044,19 @@ def screenshot(
         temp_fd, temp_path = tempfile.mkstemp(suffix=".png", prefix="aedt_screenshot_")
         os.close(temp_fd)
 
-        # Use Hfss/application-level export which works over gRPC
+        # Use application-level export which works over gRPC
         try:
             from ansys.aedt.core import get_pyaedt_app
 
             app = get_pyaedt_app(
-                project_name=desktop.active_project().GetName() if design_name is None else None,
                 design_name=design_name,
+                desktop=desktop,
             )
-            app.post.export_model_picture(temp_path)
-        except Exception:
-            try:
-                # Fallback: export_design_preview_to_jpg
-                if hasattr(desktop, "export_design_preview_to_jpg"):
-                    desktop.export_design_preview_to_jpg(temp_path)
-                else:
-                    desktop.odesktop.ExportImage(temp_path, 1920, 1080)
-            except Exception as e:
-                logger.warning(f"Screenshot export failed: {e}")
-                return [TextContent(type="text", text=f"Screenshot capture failed: {str(e)}")]
+            app.post.export_model_picture(full_name=temp_path)
+            app.release_desktop(False, False)
+        except Exception as e:
+            logger.warning(f"Screenshot export failed: {e}")
+            return [TextContent(type="text", text=f"Screenshot capture failed: {str(e)}")]
 
         # Verify file was created
         image_path = Path(temp_path)
@@ -1134,7 +1131,7 @@ def export_touchstone(
 
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app()
+        app_instance = get_pyaedt_app(desktop=desktop)
 
         if not hasattr(app_instance, "export_touchstone"):
             return f"Touchstone export is not available for {type(app_instance).__name__} designs. Requires HFSS, Circuit, or similar RF design."
@@ -1201,7 +1198,10 @@ def export_3d_model(
 
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app(design_name=design_name)
+        app_instance = get_pyaedt_app(
+            design_name=design_name,
+            desktop=desktop,
+        )
 
         format_map = {"step": ".step", "iges": ".iges", "sat": ".sat", "stl": ".stl"}
         file_ext = format_map[fmt]

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -8,7 +8,9 @@ Icepak, Circuit, Q3D, and more.
 import base64
 import json
 import os
+import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Literal
 
@@ -17,15 +19,56 @@ from fastmcp.server.server import get_logger
 from mcp.types import ImageContent, TextContent
 
 from ansys.aedt.mcp import app
-from ansys.aedt.mcp.helpers import _is_docker, _probe_grpc_endpoint, get_aedt_info
+from ansys.aedt.mcp.helpers import _is_docker, _probe_grpc_endpoint, _resolve_aedt_executable, get_aedt_info
 from ansys.aedt.mcp.server import session
 
 logger = get_logger(__name__)
 
 # Tool timeout tiers (seconds)
 _TIMEOUT_QUICK = 30       # status checks, listing, info queries
-_TIMEOUT_MEDIUM = 120     # connect, launch, open/save, create design, screenshot
-_TIMEOUT_LONG = 300       # script execution, analysis, exports
+_TIMEOUT_MEDIUM = 120     # connect, open/save, create design, screenshot
+_TIMEOUT_LONG = 600       # launch, script execution, analysis, exports
+
+
+def _connect_desktop(
+    port: int,
+    machine: str = "localhost",
+    version: str | None = None,
+    non_graphical: bool = True,
+) -> Any:
+    """Connect to an AEDT Desktop instance via gRPC (shared helper).
+
+    Parameters
+    ----------
+    port : int
+        The gRPC port where AEDT is listening.
+    machine : str
+        The machine hostname or IP. Default ``"localhost"``.
+    version : str | None
+        AEDT version string. ``None`` for auto-detect.
+    non_graphical : bool
+        Whether AEDT is running in non-graphical mode.
+
+    Returns
+    -------
+    Desktop
+        Connected PyAEDT Desktop instance.
+    """
+    from ansys.aedt.core import Desktop
+    from ansys.aedt.core.generic.settings import settings as aedt_settings
+
+    aedt_settings.use_grpc_api = True
+
+    kwargs: dict[str, Any] = {
+        "non_graphical": non_graphical,
+        "new_desktop": False,
+        "machine": machine,
+        "port": port,
+    }
+    if version is not None:
+        kwargs["version"] = version
+
+    return Desktop(**kwargs)
 
 
 # AEDT Application types supported
@@ -98,55 +141,35 @@ def check_aedt_installed(ctx: Context) -> str:
     if _is_docker():
         host = os.environ.get("AEDT_MACHINE", "host.docker.internal")
         port = int(os.environ.get("AEDT_PORT", "50051"))
-        reachable = _probe_grpc_endpoint(host, port)
-        if reachable:
+        probe = _probe_grpc_endpoint(host, port)
+        if probe["reachable"]:
             return (
                 f"Running inside Docker – AEDT gRPC endpoint at "
                 f"{host}:{port} is reachable."
             )
         return (
             f"Running inside Docker – AEDT gRPC endpoint at "
-            f"{host}:{port} is NOT reachable. Ensure AEDT is started "
-            f"with: ansysedt.exe -grpcsrv {port}"
+            f"{host}:{port} is NOT reachable (error: {probe['error']}). "
+            f"Ensure AEDT is started with: ansysedt.exe -grpcsrv {port}"
         )
 
     # ------- Native path: search for local installation -------
     try:
-        from ansys.aedt.core.desktop import Desktop
-
-        # Get installed versions without starting AEDT
-        temp_desktop = Desktop.__new__(Desktop)
-        installed = getattr(temp_desktop, 'installed_versions', {})
-
-        if installed:
-            versions = list(installed.keys())
-            logger.info(f"AEDT installations found: {versions}")
-            return f"AEDT is installed on this system.\nAvailable versions: {', '.join(str(v) for v in versions)}"
-        else:
-            # Try alternative detection
-            import subprocess
-            result = subprocess.run(
-                ["where", "ansysedt.exe"],
-                capture_output=True,
-                text=True,
-                timeout=30
-            )
-            if result.returncode == 0:
-                return f"AEDT executable found at: {result.stdout.strip()}"
-            else:
-                return (
-                    "AEDT is not installed on this system or cannot be found. "
-                    "Please ensure ANSYS Electronics Desktop is properly installed "
-                    "and the installation path is in the system PATH."
-                )
-
+        target_version, aedt_exe = _resolve_aedt_executable()
+        return (
+            f"AEDT is installed on this system.\n"
+            f"Version: {target_version}\n"
+            f"Executable: {aedt_exe}"
+        )
+    except RuntimeError as e:
+        return str(e)
     except Exception as e:
         error_msg = f"Error checking AEDT installation: {str(e)}"
         logger.error(error_msg)
         return error_msg
 
 
-@app.tool(tags={"aali", "locked_connection"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aali", "locked_connection"}, timeout=_TIMEOUT_LONG)
 def launch_aedt(
     ctx: Context,
     version: str | None = None,
@@ -155,9 +178,9 @@ def launch_aedt(
 ) -> str:
     """Launch a new AEDT Desktop instance.
 
-    This tool starts a new AEDT Desktop instance using PyAEDT's Desktop class.
-    The launched instance will be automatically connected and stored in the context
-    for subsequent operations.
+    This tool starts a new AEDT Desktop instance and automatically detects
+    when it is ready by polling the gRPC port. The launched instance will be
+    connected and stored in the context for subsequent operations.
 
     Parameters
     ----------
@@ -179,7 +202,6 @@ def launch_aedt(
     """
     logger.info("Launching new AEDT Desktop instance...")
 
-    # Docker guard: launching a local AEDT inside a container is not supported
     if _is_docker():
         return (
             "Launching a local AEDT instance from inside a Docker container "
@@ -188,36 +210,63 @@ def launch_aedt(
         )
 
     try:
-        # Check if there's already a connection
         if ctx.request_context.lifespan_context.desktop is not None:
             return (
                 "Already connected to an AEDT Desktop instance. "
                 "Please disconnect first using disconnect_from_aedt tool."
             )
 
-        from ansys.aedt.core import Desktop
+        # Step 1: Resolve version & executable
+        target_version, aedt_exe = _resolve_aedt_executable(version)
 
-        # Launch new AEDT instance
-        kwargs: dict[str, Any] = {
-            "non_graphical": non_graphical,
-            "new_desktop": new_desktop,
+        # Pick a free gRPC port
+        import socket
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            grpc_port = s.getsockname()[1]
+
+        # Step 2: Spawn AEDT and poll for readiness
+        command = [str(aedt_exe), "-grpcsrv", str(grpc_port)]
+        if non_graphical:
+            command.append("-ng")
+
+        popen_kwargs: dict[str, Any] = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
         }
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.DETACHED_PROCESS
 
-        if version is not None:
-            kwargs["version"] = version
+        proc = subprocess.Popen(command, **popen_kwargs)
+        logger.info(f"AEDT spawned (PID {proc.pid}), waiting for gRPC port {grpc_port}...")
 
-        desktop = Desktop(**kwargs)
+        max_wait, poll_interval, elapsed = 300, 3, 0
+        while elapsed < max_wait:
+            if _probe_grpc_endpoint("127.0.0.1", grpc_port, timeout=2.0)["reachable"]:
+                break
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+        else:
+            return (
+                f"AEDT process started (PID {proc.pid}) but gRPC port {grpc_port} "
+                f"did not become available within {max_wait}s. "
+                f"Try connect_to_aedt with port={grpc_port} once it's ready."
+            )
 
-        # Store in context for later use
+        # Step 3: Connect via shared helper
+        desktop = _connect_desktop(
+            port=grpc_port, version=target_version, non_graphical=non_graphical,
+        )
         ctx.request_context.lifespan_context.desktop = desktop
+        ctx.request_context.lifespan_context.aedt_port = grpc_port
 
-        logger.info(f"AEDT launched successfully! Version: {desktop.aedt_version_id}")
         return (
             f"Successfully launched AEDT Desktop\n"
             f"Version: {desktop.aedt_version_id}\n"
-            f"Installation Directory: {desktop.aedt_install_dir}\n"
-            f"Non-graphical Mode: {non_graphical}\n"
-            f"gRPC Mode: {desktop.is_grpc_api}\n"
+            f"gRPC Port: {grpc_port}\n"
+            f"PID: {proc.pid}\n"
+            f"Startup Time: ~{elapsed}s\n"
         )
 
     except Exception as e:
@@ -280,24 +329,18 @@ def connect_to_aedt(
                 "Please disconnect first using disconnect_from_aedt tool."
             )
 
-        from ansys.aedt.core import Desktop
         from ansys.aedt.core.generic.settings import settings
 
         # Enable gRPC API
         settings.use_grpc_api = True
 
-        # Connect to existing AEDT instance
-        kwargs: dict[str, Any] = {
-            "non_graphical": non_graphical,
-            "new_desktop": False,  # Connect to existing
-            "machine": machine,
-            "port": port,
-        }
-
-        if version is not None:
-            kwargs["version"] = version
-
-        desktop = Desktop(**kwargs)
+        # Connect to existing AEDT instance using shared helper
+        desktop = _connect_desktop(
+            port=port,
+            machine=machine,
+            version=version,
+            non_graphical=non_graphical,
+        )
 
         # Store in context for later use
         ctx.request_context.lifespan_context.desktop = desktop
@@ -429,6 +472,10 @@ def run_python_code(ctx: Context, code: str) -> str:
     try:
         logger.info("Executing inline Python code in AEDT...")
 
+        # Prevent exec'd code from closing the desktop session on error/GC
+        original_close_on_exit = desktop.close_on_exit
+        desktop.close_on_exit = False
+
         # Create a local namespace with desktop available
         local_ns = {
             "desktop": desktop,
@@ -447,6 +494,12 @@ def run_python_code(ctx: Context, code: str) -> str:
         error_msg = f"Error executing code: {str(e)}"
         logger.error(error_msg)
         return error_msg
+    finally:
+        # Restore close_on_exit setting
+        try:
+            desktop.close_on_exit = original_close_on_exit
+        except Exception:
+            pass
 
 
 @app.tool(timeout=_TIMEOUT_QUICK)
@@ -716,11 +769,18 @@ def analyze_design(
     try:
         logger.info(f"Running analysis on setup: {setup_name or 'all setups'}")
 
-        # Get active project and analyze
+        from ansys.aedt.core import get_pyaedt_app
+
+        app = get_pyaedt_app(design_name=design_name)
+
+        kwargs = {}
+        if num_cores is not None:
+            kwargs["num_cores"] = num_cores
+
         if setup_name:
-            result = desktop.analyze_all(design=design_name, setup=setup_name)
+            result = app.analyze_setup(setup_name, **kwargs)
         else:
-            result = desktop.analyze_all(design=design_name)
+            result = app.analyze(**kwargs)
 
         return f"Analysis completed successfully.\nResult: {result}"
 
@@ -764,9 +824,40 @@ def export_results(
     try:
         logger.info(f"Exporting {export_type} results to: {output_path}")
 
-        # This would need access to the active application
-        # For now, return a placeholder
-        return f"Export functionality requires an active application instance. Use create_design first to create an app-specific connection."
+        from ansys.aedt.core import get_pyaedt_app
+
+        app_instance = get_pyaedt_app()
+
+        setup_kwargs = {}
+        if setup_name is not None:
+            setup_kwargs["setup_name"] = setup_name
+
+        if export_type == "touchstone":
+            if not hasattr(app_instance, "export_touchstone"):
+                return f"Touchstone export is not available for {type(app_instance).__name__} designs."
+            result = app_instance.export_touchstone(output_file=output_path, **setup_kwargs)
+            return f"Touchstone exported to: {output_path}\nResult: {result}"
+
+        elif export_type == "profile":
+            if not hasattr(app_instance, "export_profile"):
+                return f"Profile export is not available for {type(app_instance).__name__} designs."
+            result = app_instance.export_profile(**setup_kwargs)
+            return f"Profile exported successfully.\nResult: {result}"
+
+        elif export_type == "convergence":
+            if not hasattr(app_instance, "export_convergence"):
+                return f"Convergence export is not available for {type(app_instance).__name__} designs."
+            result = app_instance.export_convergence(**setup_kwargs)
+            return f"Convergence data exported.\nResult: {result}"
+
+        elif export_type == "mesh":
+            if not hasattr(app_instance, "export_mesh_stats"):
+                return f"Mesh export is not available for {type(app_instance).__name__} designs."
+            result = app_instance.export_mesh_stats(**setup_kwargs)
+            return f"Mesh stats exported.\nResult: {result}"
+
+        else:
+            return f"Unknown export type: {export_type}. Supported: touchstone, profile, convergence, mesh."
 
     except Exception as e:
         error_msg = f"Error exporting results: {str(e)}"
@@ -943,22 +1034,29 @@ def screenshot(
     try:
         logger.info(f"Capturing AEDT screenshot (type: {plot_type})...")
 
-        # Create a temporary file with .jpg extension
-        temp_fd, temp_path = tempfile.mkstemp(suffix=".jpg", prefix="aedt_screenshot_")
+        # Create a temporary file with .png extension
+        temp_fd, temp_path = tempfile.mkstemp(suffix=".png", prefix="aedt_screenshot_")
         os.close(temp_fd)
 
-        # Use Desktop's export_design_preview_to_jpg if available
+        # Use Hfss/application-level export which works over gRPC
         try:
-            # Try to export design preview
-            if hasattr(desktop, "export_design_preview_to_jpg"):
-                desktop.export_design_preview_to_jpg(temp_path)
-            else:
-                # Alternative: use oDesktop.ExportImage if available
-                desktop.odesktop.ExportImage(temp_path, 1920, 1080)
-        except Exception as e:
-            logger.warning(f"Design preview export failed, trying alternative: {e}")
-            # If export fails, return error
-            return [TextContent(type="text", text=f"Screenshot capture failed: {str(e)}")]
+            from ansys.aedt.core import get_pyaedt_app
+
+            app = get_pyaedt_app(
+                project_name=desktop.active_project().GetName() if design_name is None else None,
+                design_name=design_name,
+            )
+            app.post.export_model_picture(temp_path)
+        except Exception:
+            try:
+                # Fallback: export_design_preview_to_jpg
+                if hasattr(desktop, "export_design_preview_to_jpg"):
+                    desktop.export_design_preview_to_jpg(temp_path)
+                else:
+                    desktop.odesktop.ExportImage(temp_path, 1920, 1080)
+            except Exception as e:
+                logger.warning(f"Screenshot export failed: {e}")
+                return [TextContent(type="text", text=f"Screenshot capture failed: {str(e)}")]
 
         # Verify file was created
         image_path = Path(temp_path)
@@ -973,13 +1071,19 @@ def screenshot(
         base64_data = base64.b64encode(image_data).decode("utf-8")
 
         # Determine mime type
-        mime_type = "image/jpeg"
+        mime_type = "image/png" if temp_path.endswith(".png") else "image/jpeg"
 
         logger.info(f"Screenshot captured successfully: {temp_path}")
 
+        # Clean up temp file
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
         # Return both text (file path) and image content
         return [
-            TextContent(type="text", text=f"Screenshot saved to: {temp_path}"),
+            TextContent(type="text", text="Screenshot captured successfully."),
             ImageContent(type="image", data=base64_data, mimeType=mime_type),
         ]
 
@@ -1025,13 +1129,25 @@ def export_touchstone(
     try:
         logger.info(f"Exporting Touchstone to: {output_path}")
 
-        # Note: This requires an active HFSS or similar RF design
-        # The actual implementation depends on the active application type
-        return (
-            f"Touchstone export configured for: {output_path}\n"
-            "Note: Actual export requires an active RF simulation design (HFSS, Circuit, etc.) "
-            "with completed analysis. Use create_design and analyze_design first."
-        )
+        from ansys.aedt.core import get_pyaedt_app
+
+        app_instance = get_pyaedt_app()
+
+        if not hasattr(app_instance, "export_touchstone"):
+            return f"Touchstone export is not available for {type(app_instance).__name__} designs. Requires HFSS, Circuit, or similar RF design."
+
+        kwargs: dict[str, Any] = {"output_file": output_path}
+        if setup_name:
+            kwargs["setup_name"] = setup_name
+        if solution_name:
+            kwargs["sweep_name"] = solution_name
+
+        result = app_instance.export_touchstone(**kwargs)
+
+        if result and os.path.exists(output_path):
+            size = os.path.getsize(output_path)
+            return f"Touchstone exported successfully to: {output_path} ({size} bytes)"
+        return f"Touchstone export completed. Result: {result}"
 
     except Exception as e:
         error_msg = f"Error exporting Touchstone: {str(e)}"
@@ -1075,16 +1191,32 @@ def export_3d_model(
     try:
         logger.info(f"Exporting 3D model to {export_format}: {output_path}")
 
-        # Validate format
         supported_formats = ["step", "iges", "sat", "stl"]
-        if export_format.lower() not in supported_formats:
+        fmt = export_format.lower()
+        if fmt not in supported_formats:
             return f"Unsupported format: {export_format}. Supported: {supported_formats}"
 
-        return (
-            f"3D model export configured for: {output_path} (format: {export_format})\n"
-            "Note: Actual export requires an active 3D design with geometry. "
-            "Use create_design first to set up the application."
+        from ansys.aedt.core import get_pyaedt_app
+
+        app_instance = get_pyaedt_app(design_name=design_name)
+
+        format_map = {"step": ".step", "iges": ".iges", "sat": ".sat", "stl": ".stl"}
+        file_ext = format_map[fmt]
+
+        file_dir = os.path.dirname(output_path) or "."
+        file_base = os.path.splitext(os.path.basename(output_path))[0]
+
+        # Use modeler.export_3d_model which accepts file_name + file_path separately
+        result = app_instance.modeler.export_3d_model(
+            file_name=file_base,
+            file_path=file_dir,
+            file_format=file_ext,
         )
+
+        if os.path.exists(output_path):
+            size = os.path.getsize(output_path)
+            return f"3D model exported to: {output_path} ({size} bytes, format: {fmt})"
+        return f"3D model export completed. Result: {result}"
 
     except Exception as e:
         error_msg = f"Error exporting 3D model: {str(e)}"
@@ -1116,15 +1248,17 @@ def clear_aedt(ctx: Context, close_projects: bool = True) -> str:
     try:
         logger.info("Clearing AEDT state...")
 
+        closed_count = 0
         if close_projects:
             # Get list of projects and close them
             projects = desktop.project_list
             for proj in projects:
                 desktop.odesktop.CloseProject(proj)
+            closed_count = len(projects)
 
         desktop.clear_messages()
 
-        return f"AEDT state cleared. Closed {len(projects) if close_projects else 0} project(s)."
+        return f"AEDT state cleared. Closed {closed_count} project(s)."
 
     except Exception as e:
         error_msg = f"Error clearing AEDT: {str(e)}"


### PR DESCRIPTION
Bug fixes, API corrections, and optimizations for pyaedt-mcp tools, validated live against AEDT 2025 R2.

## Changes
- contexts.py: Fix start/stop -> start_frequency/stop_frequency in HFSS sweep guidelines
- helpers.py: Add _resolve_aedt_executable() helper, self-contained _is_docker()/_probe_grpc_endpoint()
- tools.py: Remove _TIMEOUT_LAUNCH, extract _connect_desktop() shared helper, optimize launch_aedt, fix clear_aedt/analyze_design/export_results/export_3d_model, implement export tools, add close_on_exit guard, screenshot cleanup
- examples: Add validated HFSS patch antenna workflow