### PR TITLE
fix: ensure all tools and guidelines reuse the launched AEDT session

### DIFF
--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -7,6 +7,11 @@ ANSYS AEDT 2025 R2 on April 20, 2026.
 > **GUI Mode:** Launch AEDT with `non_graphical=false` so the GUI is visible
 > and you can see the antenna geometry, solved mesh, and S11 report plot
 > interactively in the AEDT window.
+>
+> **IMPORTANT:** When creating PyAEDT app instances (Hfss, Maxwell3d, etc.)
+> inside `run_python_code`, always pass `port=desktop.port` to ensure the
+> app connects to the **same** AEDT Desktop instance that was launched.
+> Without `port=`, PyAEDT may connect to a different or new AEDT process.
 
 ## 1. Check AEDT Installation
 
@@ -61,7 +66,7 @@ Response:
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create substrate (40x40x1.6 mm FR4)
 substrate = hfss.modeler.create_box(
@@ -105,7 +110,7 @@ Response: Geometry and boundaries created. Objects: ['Substrate', 'Ground', 'Pat
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Feed line (3mm wide, centered in X, from y=0 to patch edge at y=8mm)
 feed_x = (40 - 3) / 2
@@ -156,7 +161,7 @@ Response: Feed, port, and airbox added. Objects: ['FeedLine', 'Substrate', 'Grou
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create setup at 2.4 GHz
 setup = hfss.create_setup(name="Setup1")
@@ -200,7 +205,7 @@ Returns a PNG image of the AEDT viewport showing the antenna geometry.
 ```python
 import time
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 hfss.save_project()
 t0 = time.time()
@@ -224,7 +229,7 @@ Response: Solved: True, Time: 81s
 import os, math
 from ansys.aedt.core import Hfss
 
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create S11 report via native API
 report_module = hfss.odesign.GetModule("ReportSetup")
@@ -281,7 +286,7 @@ Returns a PNG showing the S11_Return_Loss report visible in the AEDT GUI.
 import os
 from ansys.aedt.core import Hfss
 
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 step_path = r"D:\ANSYS-DEV\screenshots\PatchAntenna_Validation.step"
 export_ok = hfss.export_3d_model(

--- a/src/ansys/aedt/mcp/contexts.py
+++ b/src/ansys/aedt/mcp/contexts.py
@@ -83,8 +83,8 @@ from ansys.aedt.core import Hfss, Desktop
 # Launch or connect to AEDT
 desktop = Desktop(version="2025.2", non_graphical=True)
 
-# Create an application
-hfss = Hfss(project="MyProject", design="MyDesign")
+# Create an application — ALWAYS pass port=desktop.port to reuse the same AEDT instance
+hfss = Hfss(project="MyProject", design="MyDesign", port=desktop.port)
 
 # Create geometry
 box = hfss.modeler.create_box([0, 0, 0], [10, 10, 2], name="Substrate", material="FR4_epoxy")
@@ -146,8 +146,8 @@ HFSS (High Frequency Structure Simulator) is used for high-frequency electromagn
 ```python
 from ansys.aedt.core import Hfss
 
-# Create HFSS design
-hfss = Hfss(project="Antenna", design="PatchAntenna", solution_type="Modal")
+# Create HFSS design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
+hfss = Hfss(project="Antenna", design="PatchAntenna", solution_type="Modal", port=desktop.port)
 
 # Set units
 hfss.modeler.model_units = "mm"
@@ -294,11 +294,12 @@ Maxwell is used for low-frequency electromagnetic simulations including electric
 ```python
 from ansys.aedt.core import Maxwell3d
 
-# Create Maxwell 3D design
+# Create Maxwell 3D design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 m3d = Maxwell3d(
     project="Motor",
     design="IPM_Motor",
-    solution_type="Transient"
+    solution_type="Transient",
+    port=desktop.port
 )
 
 # Set units
@@ -439,11 +440,12 @@ Icepak is used for thermal management and CFD analysis of electronic systems.
 ```python
 from ansys.aedt.core import Icepak
 
-# Create Icepak design
+# Create Icepak design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 ipk = Icepak(
     project="PCB_Cooling",
     design="ThermalAnalysis",
-    solution_type="SteadyState"
+    solution_type="SteadyState",
+    port=desktop.port
 )
 
 # Set units
@@ -600,10 +602,11 @@ Circuit Design is used for circuit-level simulations, system integration, and co
 ```python
 from ansys.aedt.core import Circuit
 
-# Create Circuit design
+# Create Circuit design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 cir = Circuit(
     project="Filter",
-    design="LPF"
+    design="LPF",
+    port=desktop.port
 )
 
 # Create schematic components
@@ -667,13 +670,13 @@ cir.export_touchstone("filter_output.s2p", setup_name="LinearSetup")
 ```python
 from ansys.aedt.core import Circuit, Hfss
 
-# Create HFSS design first
-hfss = Hfss(project="System", design="Antenna3D")
+# Create HFSS design first — ALWAYS pass port=desktop.port
+hfss = Hfss(project="System", design="Antenna3D", port=desktop.port)
 # ... create 3D model ...
 hfss.analyze()
 
 # Create Circuit design in same project
-cir = Circuit(project="System", design="MatchingNetwork")
+cir = Circuit(project="System", design="MatchingNetwork", port=desktop.port)
 
 # Import HFSS design as dynamic link
 cir.modeler.schematic.add_subcircuit_dynamic_link(

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -344,6 +344,7 @@ def connect_to_aedt(
 
         # Store in context for later use
         ctx.request_context.lifespan_context.desktop = desktop
+        ctx.request_context.lifespan_context.aedt_port = port
 
         logger.info(f"Connected to AEDT successfully at {machine}:{port}!")
         return (
@@ -458,6 +459,7 @@ def run_python_code(ctx: Context, code: str) -> str:
         The Python code to execute. The code has access to:
         - `desktop`: The PyAEDT Desktop instance
         - `odesktop`: The native AEDT oDesktop COM object
+        - `aedt_port`: The gRPC port of the connected AEDT instance
 
     Returns
     -------
@@ -477,9 +479,11 @@ def run_python_code(ctx: Context, code: str) -> str:
         desktop.close_on_exit = False
 
         # Create a local namespace with desktop available
+        # Include aedt_port so user code can do Hfss(..., port=aedt_port)
         local_ns = {
             "desktop": desktop,
             "odesktop": desktop.odesktop,
+            "aedt_port": getattr(desktop, "port", ctx.request_context.lifespan_context.aedt_port),
         }
 
         # Execute the code
@@ -1053,7 +1057,6 @@ def screenshot(
                 desktop=desktop,
             )
             app.post.export_model_picture(full_name=temp_path)
-            app.release_desktop(False, False)
         except Exception as e:
             logger.warning(f"Screenshot export failed: {e}")
             return [TextContent(type="text", text=f"Screenshot capture failed: {str(e)}")]


### PR DESCRIPTION
## Summary

Fixes session-reuse bugs where un_python_code and screenshot could connect to a different AEDT instance than the one launched/connected by the MCP server.

## Changes

### 	ools.py
- **connect_to_aedt**: Now stores edt_port in context (was only set by launch_aedt)
- **un_python_code**: Injects edt_port into the exec namespace so user code can do Hfss(..., port=aedt_port) 
- **screenshot**: Removed pp.release_desktop(False, False) call which could invalidate internal PyAEDT references for subsequent tools

### contexts.py (Guidelines)
- All guideline code examples (workflow overview, HFSS, Maxwell, Icepak, Circuit, co-simulation) now include port=desktop.port on every PyAEDT app constructor

### xamples/hfss_patch_antenna_workflow.md
- All 6 Hfss() calls updated to include port=desktop.port
- Added warning note about the port=desktop.port requirement

## Root Cause

When Hfss(project=..., design=...) is called **without** port=, PyAEDT negotiates a fresh connection and may attach to a different AEDT process. The launched AEDT GUI stays empty while work happens in a hidden session.