### PR TITLE
fix: add port=desktop.port to guideline examples for AEDT session reuse

### DIFF
--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -61,7 +61,7 @@ Response:
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create substrate (40x40x1.6 mm FR4)
 substrate = hfss.modeler.create_box(
@@ -105,7 +105,7 @@ Response: Geometry and boundaries created. Objects: ['Substrate', 'Ground', 'Pat
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Feed line (3mm wide, centered in X, from y=0 to patch edge at y=8mm)
 feed_x = (40 - 3) / 2
@@ -156,7 +156,7 @@ Response: Feed, port, and airbox added. Objects: ['FeedLine', 'Substrate', 'Grou
 
 ```python
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create setup at 2.4 GHz
 setup = hfss.create_setup(name="Setup1")
@@ -200,7 +200,7 @@ Returns a PNG image of the AEDT viewport showing the antenna geometry.
 ```python
 import time
 from ansys.aedt.core import Hfss
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 hfss.save_project()
 t0 = time.time()
@@ -224,7 +224,7 @@ Response: Solved: True, Time: 81s
 import os, math
 from ansys.aedt.core import Hfss
 
-hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation")
+hfss = Hfss(project=desktop.project_list[0], design="PatchAntenna_Validation", port=desktop.port)
 
 # Create S11 report via native API
 report_module = hfss.odesign.GetModule("ReportSetup")

--- a/src/ansys/aedt/mcp/contexts.py
+++ b/src/ansys/aedt/mcp/contexts.py
@@ -83,8 +83,8 @@ from ansys.aedt.core import Hfss, Desktop
 # Launch or connect to AEDT
 desktop = Desktop(version="2026.1", non_graphical=True)
 
-# Create an application
-hfss = Hfss(project="MyProject", design="MyDesign")
+# Create an application — ALWAYS pass port=desktop.port to reuse the same AEDT instance
+hfss = Hfss(project="MyProject", design="MyDesign", port=desktop.port)
 
 # Create geometry
 box = hfss.modeler.create_box([0, 0, 0], [10, 10, 2], name="Substrate", material="FR4_epoxy")
@@ -146,8 +146,8 @@ HFSS (High Frequency Structure Simulator) is used for high-frequency electromagn
 ```python
 from ansys.aedt.core import Hfss
 
-# Create HFSS design
-hfss = Hfss(project="Antenna", design="PatchAntenna", solution_type="Modal")
+# Create HFSS design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
+hfss = Hfss(project="Antenna", design="PatchAntenna", solution_type="Modal", port=desktop.port)
 
 # Set units
 hfss.modeler.model_units = "mm"
@@ -294,11 +294,12 @@ Maxwell is used for low-frequency electromagnetic simulations including electric
 ```python
 from ansys.aedt.core import Maxwell3d
 
-# Create Maxwell 3D design
+# Create Maxwell 3D design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 m3d = Maxwell3d(
     project="Motor",
     design="IPM_Motor",
-    solution_type="Transient"
+    solution_type="Transient",
+    port=desktop.port
 )
 
 # Set units
@@ -439,11 +440,12 @@ Icepak is used for thermal management and CFD analysis of electronic systems.
 ```python
 from ansys.aedt.core import Icepak
 
-# Create Icepak design
+# Create Icepak design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 ipk = Icepak(
     project="PCB_Cooling",
     design="ThermalAnalysis",
-    solution_type="SteadyState"
+    solution_type="SteadyState",
+    port=desktop.port
 )
 
 # Set units
@@ -600,10 +602,11 @@ Circuit Design is used for circuit-level simulations, system integration, and co
 ```python
 from ansys.aedt.core import Circuit
 
-# Create Circuit design
+# Create Circuit design — ALWAYS pass port=desktop.port to reuse the launched AEDT instance
 cir = Circuit(
     project="Filter",
-    design="LPF"
+    design="LPF",
+    port=desktop.port
 )
 
 # Create schematic components
@@ -667,13 +670,13 @@ cir.export_touchstone("filter_output.s2p", setup_name="LinearSetup")
 ```python
 from ansys.aedt.core import Circuit, Hfss
 
-# Create HFSS design first
-hfss = Hfss(project="System", design="Antenna3D")
+# Create HFSS design first — ALWAYS pass port=desktop.port
+hfss = Hfss(project="System", design="Antenna3D", port=desktop.port)
 # ... create 3D model ...
 hfss.analyze()
 
 # Create Circuit design in same project
-cir = Circuit(project="System", design="MatchingNetwork")
+cir = Circuit(project="System", design="MatchingNetwork", port=desktop.port)
 
 # Import HFSS design as dynamic link
 cir.modeler.schematic.add_subcircuit_dynamic_link(

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -436,6 +436,7 @@ def launch_aedt(
 
         # Store in context for later use
         ctx.request_context.lifespan_context.desktop = desktop
+        ctx.request_context.lifespan_context.aedt_port = getattr(desktop, "port", None)
 
         logger.info(f"AEDT launched successfully! Target: {launched_target}")
         return (
@@ -538,6 +539,7 @@ def connect_to_aedt(
 
         # Store in context for later use
         ctx.request_context.lifespan_context.desktop = desktop
+        ctx.request_context.lifespan_context.aedt_port = port
 
         logger.info(f"Connected to AEDT successfully at {machine}:{port}!")
         message = (
@@ -662,6 +664,7 @@ def run_python_code(ctx: Context, code: str) -> str:
         The Python code to execute. The code has access to:
         - `desktop`: The PyAEDT Desktop instance
         - `odesktop`: The native AEDT oDesktop COM object
+        - `aedt_port`: The gRPC port of the connected AEDT instance
 
     Returns
     -------
@@ -680,9 +683,11 @@ def run_python_code(ctx: Context, code: str) -> str:
 
         _configure_pyaedt_runtime_settings()
 
+        # Include aedt_port so user code can do Hfss(..., port=aedt_port)
         local_ns = {
             "desktop": desktop,
             "odesktop": desktop.odesktop,
+            "aedt_port": getattr(desktop, "port", ctx.request_context.lifespan_context.aedt_port),
         }
 
         exec(code, local_ns)


### PR DESCRIPTION
## Problem

When the LLM generates Python code via un_python_code, it looks at the guideline examples in contexts.py to learn the correct patterns. Without port=desktop.port in those examples, the generated code creates Hfss(...) / Maxwell3d(...) / etc. without specifying the port, causing PyAEDT to connect to a different or new AEDT instance instead of reusing the one launched by the MCP server.

## Changes

- **contexts.py**: All guideline code examples now include port=desktop.port (Hfss, Maxwell3d, Icepak, Circuit, co-simulation)
- **tools.py**: launch_aedt and connect_to_aedt store edt_port in context
- **tools.py**: un_python_code exposes edt_port in the exec namespace (defense-in-depth; desktop.port already works)
- **examples/**: hfss_patch_antenna_workflow updated with port=desktop.port

## Why this matters

Without this fix, every un_python_code call that instantiates a PyAEDT app object (Hfss, Maxwell3d, etc.) risks spawning a new AEDT Desktop session instead of reusing the existing one — leading to orphaned processes and failed workflows.