### PR TITLE
feat: connection-aware tool visibility + consolidated guidelines tool

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
-max-line-length = 70
-extend-ignore = E501,W503
+max-line-length = 100
+extend-ignore = W503
 exclude =
     .git,
     .venv,

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: 'doc/source/**/*'
+  - any-glob-to-any-file: 'examples/**/*'
+maintenance:
+- changed-files:
+  - any-glob-to-any-file: '.github/**/*'
+  - any-glob-to-any-file: 'pyproject.toml'
+testing:
+- changed-files:
+  - any-glob-to-any-file:  'tests/*'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,35 @@
+- name: bug
+  description: Something isn't working
+  color: d42a34
+
+- name: dependencies
+  description: Related with project dependencies
+  color: ffc0cb
+
+- name: documentation
+  description: Improvements or additions to documentation
+  color: 0677ba
+
+- name: enhancement
+  description: New features or code improvements
+  color: FFD827
+
+- name: good first issue
+  description: Easy to solve for newcomers
+  color: 62ca50
+
+- name: maintenance
+  description: Package and maintenance related
+  color: f78c37
+
+- name: release
+  description: Anything related to an incoming release
+  color: ffffff
+
+- name: testing
+  description: Tests and test related changes
+  color: c5def5
+
+- name: pr-preview
+  description: PR preview related
+  color: 051e7f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,95 +1,161 @@
-# CI workflow for PyAEDT MCP Server
-name: CI
+name: CI/CD
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
   pull_request:
-    branches: [main]
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
-  PYTHON_VERSION: "3.12"
+  ON_CI: "true"
+  MAIN_PYTHON_VERSION: "3.12"
+  PACKAGE_NAME: "ansys-aedt-mcp"
+  DOCUMENTATION_CNAME: "aedt-mcp.docs.pyansys.com"
 
 jobs:
-  # ------------------------------------------------------------------ #
-  # Code style checks
-  # ------------------------------------------------------------------ #
-  code-style:
-    name: Code style
+
+  update-changelog:
+    name: "Update CHANGELOG (on release)"
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: ansys/actions/doc-deploy-changelog@v10
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Run pre-commit hooks
-        run: pre-commit run --all-files
-
-  # ------------------------------------------------------------------ #
-  # Unit tests
-  # ------------------------------------------------------------------ #
-  tests:
-    name: Tests (Python ${{ matrix.python-version }})
-    needs: code-style
+  lint:
+    name: "Code style checks"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: "Checkout code"
+        uses: actions/checkout@v4
 
       - name: "Configure pip for private PyPI"
         run: |
           pip config set global.extra-index-url https://${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/
 
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -e ".[dev]"
+      - name: "Cache pre-commit hooks"
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
 
-      - name: Run tests
-        run: python -m pytest tests/ -x --tb=short -q
+      - name: "Run PyAnsys code style checks"
+        uses: ansys/actions/code-style@v10
+        with:
+          checkout: false
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          use-python-cache: true
 
-  # ------------------------------------------------------------------ #
-  # Package build verification
-  # ------------------------------------------------------------------ #
-  package:
-    name: Build package
-    needs: tests
-    runs-on: ubuntu-latest
+  test:
+    name: "Test Python ${{ matrix.python-version }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    needs: [lint]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
-      - uses: actions/checkout@v4
+      - name: "Checkout code"
+        uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
-      - name: Install build tools
-        run: pip install build
+      - name: "Configure pip for private PyPI"
+        run: |
+          pip config set global.extra-index-url https://${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/
 
-      - name: Build sdist and wheel
-        run: python -m build
+      - name: "Install dependencies"
+        run: |
+          pip install --upgrade pip
+          pip install -e .[tests]
+          pip list
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: "Run unit tests"
+        run: |
+          pytest -m "not integration" --cov=ansys.aedt.mcp --cov-report=xml --cov-report=term
+
+  package:
+    name: "Package library"
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: "Configure pip for private PyPI"
+        run: |
+          pip config set global.extra-index-url https://${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/
+
+      - name: "Build library source and wheel artifacts"
+        uses: ansys/actions/build-library@v10
+        env:
+          UV_EXTRA_INDEX_URL: 'https://${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/'
         with:
-          name: pyaedt-mcp-dist
-          path: dist/
+          library-name: ${{ env.PACKAGE_NAME }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          checkout: false
+
+  release:
+    name: "Release project"
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
+    needs: [package, update-changelog]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}-artifacts
+          path: ${{ env.PACKAGE_NAME }}-artifacts
+          pattern: ${{ env.PACKAGE_NAME }}-artifacts
+
+      - name: "Display structure of downloaded files"
+        run: ls -Rla
+
+      - name: "Release to GitHub"
+        uses: ansys/actions/release-github@v10
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          only-code: true
+          add-artifact-attestation-notes: true
+          changelog-release-notes: true
+
+      - name: "Release to private PyPI"
+        uses: ansys/actions/release-pypi-private@v10
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contribute
+
+Overall guidance on contributing to a PyAnsys library appears in the
+[Contributing] topic in the *PyAnsys developer's guide*. Ensure that you
+are thoroughly familiar with this guide before attempting to contribute to
+the PyAEDT MCP project.
+
+The following contribution information is specific to PyAEDT MCP.
+
+[Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
+
+## Adding a New Tool
+
+`pyaedt-mcp` uses connection-aware tool visibility: tools that need a live
+AEDT session are hidden until `launch_aedt` or `connect_to_aedt` succeeds.
+This is enforced via tool **tags**.
+
+When you add a new `@app.tool(...)` to `src/ansys/aedt/mcp/tools.py`:
+
+- **Default case — the tool needs an AEDT connection.** Tag it with
+  `REQUIRES_AEDT_TAG` (defined at the top of `tools.py`):
+
+  ```python
+  @app.tool(tags={REQUIRES_AEDT_TAG})
+  def my_new_tool(ctx: Context, ...) -> str:
+      ...
+  ```
+
+  No further action is required — the server disables it until a session
+  exists, then `enable_components(tags={REQUIRES_AEDT_TAG})` unlocks it.
+
+- **Special case — the tool is genuinely usable BEFORE any AEDT session**
+  (e.g. an installation check or log reader). Do NOT add the tag, and add
+  the tool's name to the `ALWAYS_AVAILABLE_TOOLS` allowlist in
+  `tests/test_tools.py::TestRequiresAEDTVisibility::test_no_tool_surface_drift`.
+
+The `test_no_tool_surface_drift` test will fail if a new tool is neither
+tagged nor on the allowlist. This is intentional — it forces every
+contributor to make an explicit decision about pre-connection visibility.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,35 @@ pyaedt-mcp/
 4. Run tests: `pytest tests/ -v`
 5. Submit a pull request
 
+### Adding a New Tool
+
+`pyaedt-mcp` uses connection-aware tool visibility: tools that need a live
+AEDT session are hidden until `launch_aedt` or `connect_to_aedt` succeeds.
+This is enforced via tool **tags**.
+
+When you add a new `@app.tool(...)` to `src/ansys/aedt/mcp/tools.py`:
+
+- **Default case — the tool needs an AEDT connection.** Tag it with
+  `REQUIRES_AEDT_TAG` (defined at the top of `tools.py`):
+
+  ```python
+  @app.tool(tags={REQUIRES_AEDT_TAG})
+  def my_new_tool(ctx: Context, ...) -> str:
+      ...
+  ```
+
+  No further action is required — the server disables it until a session
+  exists, then `enable_components(tags={REQUIRES_AEDT_TAG})` unlocks it.
+
+- **Special case — the tool is genuinely usable BEFORE any AEDT session**
+  (e.g. an installation check or log reader). Do NOT add the tag, and add
+  the tool's name to the `ALWAYS_AVAILABLE_TOOLS` allowlist in
+  `tests/test_tools.py::TestRequiresAEDTVisibility::test_no_tool_surface_drift`.
+
+The `test_no_tool_surface_drift` test will fail if a new tool is neither
+tagged nor on the allowlist. This is intentional — it forces every
+contributor to make an explicit decision about pre-connection visibility.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  range: 60..100
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        target: 60%
+    patch: off
+
+codecov:
+  notify:
+    wait_for_ci: yes

--- a/examples/hfss_patch_antenna_workflow.md
+++ b/examples/hfss_patch_antenna_workflow.md
@@ -8,6 +8,22 @@ ANSYS AEDT 2026 R1 on April 20, 2026.
 > and you can see the antenna geometry, solved mesh, and S11 report plot
 > interactively in the AEDT window.
 
+## Tool Visibility Model
+
+`pyaedt-mcp` uses a connection-aware visibility model so the LLM client
+sees a small, focused tool surface up front and additional tools unlock
+once an AEDT session exists. This avoids "tool not available — connect
+first" round-trips and reduces token cost.
+
+| Stage                    | Tools available                                                                          |
+|--------------------------|------------------------------------------------------------------------------------------|
+| Server start (no AEDT)   | `check_aedt_installed`, `launch_aedt`, `connect_to_aedt`, `get_guidelines_for`           |
+| After `launch_aedt` /    | + `check_aedt_status`, `create_design`, `open_project`, `save_project`,                  |
+|     `connect_to_aedt`    | &nbsp;&nbsp; `analyze_design`, `screenshot`, `run_python_code`, `run_python_script`, ... |
+
+The expansion happens automatically as part of the launch / connect tool
+call (`await ctx.enable_components(tags={"requires_connection"})`).
+
 ## 1. Check AEDT Installation
 
 **Tool:** `check_aedt_installed`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,23 +49,37 @@ version = "0.0.1"
 
 dependencies = [
   "pyaedt[all]>=0.10.0",
-  "fastmcp>=0.1.0",
+  "fastmcp>=3.2.0,<4.0",
   "ansys-common-mcp>=0.1.0",
   "matplotlib>=3.5.0",
   "tabulate>=0.9.0",
 ]
 
 [project.optional-dependencies]
+tests = [
+  "pytest>=9.0.2",
+  "pytest-asyncio>=1.3.0",
+  "pytest-cov>=7.0.0",
+  "pytest-mock>=3.15.1",
+]
+
+doc = [
+  "ansys-sphinx-theme[changelog]==1.6.4",
+  "numpydoc==1.10.0",
+  "sphinx-autodoc-typehints==3.1.0",
+  "sphinx-notfound-page==1.1.0",
+  "sphinx==8.2.3",
+  "sphinxcontrib-video==0.4.2",
+]
+
 dev = [
-  "pytest>=7.0",
-  "pytest-asyncio>=0.21.0",
-  "pytest-cov>=4.0",
-  "pytest-mock>=3.10",
-  "black>=23.0",
-  "isort>=5.12",
-  "mypy>=1.0",
-  "flake8>=7.0",
-  "pre-commit>=3.0",
+  "ansys-aedt-mcp[tests,doc]",
+  "pre-commit>=4.0",
+  "black>=25.0",
+  "isort>=8.0",
+  "mypy>=1.8.0",
+  "flake8>=7.3.0",
+  "bandit[toml]>=1.8.0",
 ]
 
 [project.urls]
@@ -117,16 +131,3 @@ testpaths = ["tests"]
 
 [tool.uv]
 index-strategy = "unsafe-best-match"
-
-[dependency-groups]
-dev = [
-  "pytest>=9.0.2",
-  "pytest-asyncio>=1.3.0",
-  "pytest-cov>=7.0.0",
-  "pytest-mock>=3.15.1",
-  "black>=26.0",
-  "isort>=8.0",
-  "mypy>=1.0",
-  "flake8>=7.3.0",
-  "pre-commit>=4.5",
-]

--- a/src/ansys/aedt/mcp/contexts.py
+++ b/src/ansys/aedt/mcp/contexts.py
@@ -8,10 +8,24 @@ aspects of electromagnetic and thermal simulations.
 
 # flake8: noqa: E501
 
+from typing import Literal
+
 from ansys.aedt.mcp import app
 
+GuidelinesContent = Literal[
+    "workflow",
+    "hfss",
+    "maxwell",
+    "icepak",
+    "circuit",
+    "geometry",
+    "mesh",
+    "boundaries",
+    "postprocessing",
+    "parametric",
+]
 
-@app.tool(tags={"pyaedt_context"})
+
 def get_guidelines_for_workflow_overview() -> str:
     """Get general AEDT simulation workflow guidelines.
 
@@ -118,7 +132,6 @@ hfss = Hfss(machine="remote_server", port=50051)
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_hfss() -> str:
     """Get HFSS-specific workflow guidelines.
 
@@ -258,7 +271,6 @@ hfss.post.export_field_jpg(
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_maxwell() -> str:
     """Get Maxwell 2D/3D workflow guidelines.
 
@@ -415,7 +427,6 @@ m3d.post.plot_field(
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_icepak() -> str:
     """Get Icepak thermal analysis guidelines.
 
@@ -573,7 +584,6 @@ max_temp = ipk.post.get_solution_data(
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_circuit() -> str:
     """Get Circuit simulation guidelines.
 
@@ -718,7 +728,6 @@ cir.post.create_report(
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_geometry() -> str:
     """Get geometry creation guidelines for AEDT.
 
@@ -931,7 +940,6 @@ modeler.assign_material(obj, "MyMaterial")
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_mesh() -> str:
     """Get mesh setup guidelines for AEDT.
 
@@ -1104,7 +1112,6 @@ setup.props["BroadbandFrequencyRange"] = ["1GHz", "10GHz"]
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_boundaries() -> str:
     """Get boundary and excitation guidelines for AEDT.
 
@@ -1349,7 +1356,6 @@ ipk.assign_fan(
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_postprocessing() -> str:
     """Get postprocessing guidelines for AEDT.
 
@@ -1570,7 +1576,6 @@ plt.savefig("s11_plot.png")
 """
 
 
-@app.tool(tags={"pyaedt_context"})
 def get_guidelines_for_parametric() -> str:
     """Get parametric analysis and optimization guidelines for AEDT.
 
@@ -1785,3 +1790,50 @@ hfss.deactivate_variable_tuning("patch_length")
 5. **Monitor convergence** - Check that each variation converges properly
 6. **Export results regularly** - Save data for post-processing
 """
+
+
+_CONTENT_MAP = {
+    "workflow": get_guidelines_for_workflow_overview,
+    "hfss": get_guidelines_for_hfss,
+    "maxwell": get_guidelines_for_maxwell,
+    "icepak": get_guidelines_for_icepak,
+    "circuit": get_guidelines_for_circuit,
+    "geometry": get_guidelines_for_geometry,
+    "mesh": get_guidelines_for_mesh,
+    "boundaries": get_guidelines_for_boundaries,
+    "postprocessing": get_guidelines_for_postprocessing,
+    "parametric": get_guidelines_for_parametric,
+}
+
+
+@app.tool(tags={"pyaedt_context"})
+def get_guidelines_for(content: GuidelinesContent) -> str:
+    """Get PyAEDT/AEDT simulation guidelines for a specific topic.
+
+    Use this tool before writing PyAEDT or Ansys AEDT scripting code to
+    retrieve the relevant guidelines for the workflow step or solver you are
+    about to use. Call it once per topic needed; it is strongly recommended
+    before every code-generation task.
+
+    Parameters
+    ----------
+    content : str
+        The guideline topic to retrieve. One of:
+
+        - ``"workflow"``: PyAEDT workflow overview.
+        - ``"hfss"``: HFSS (high-frequency electromagnetics) guidelines.
+        - ``"maxwell"``: Maxwell (low-frequency electromagnetics).
+        - ``"icepak"``: Icepak (electronics thermal) guidelines.
+        - ``"circuit"``: Circuit / Twin Builder guidelines.
+        - ``"geometry"``: Geometry creation and modeling.
+        - ``"mesh"``: Mesh operations and refinement.
+        - ``"boundaries"``: Boundary conditions and excitations.
+        - ``"postprocessing"``: Reports, fields, and visualization.
+        - ``"parametric"``: Parametric sweeps and optimization.
+
+    Returns
+    -------
+    str
+        Guideline text for the requested topic.
+    """
+    return _CONTENT_MAP[content]()

--- a/src/ansys/aedt/mcp/contexts.py
+++ b/src/ansys/aedt/mcp/contexts.py
@@ -94,8 +94,8 @@ AEDT includes multiple physics solvers:
 ```python
 from ansys.aedt.core import Hfss, Desktop
 
-# Launch or connect to AEDT
-desktop = Desktop(version="2026.1", non_graphical=True)
+# Launch or connect to AEDT (omit ``version`` to use the latest installed AEDT)
+desktop = Desktop(non_graphical=True)
 
 # Create an application — ALWAYS pass port=desktop.port to reuse the same AEDT instance
 hfss = Hfss(project="MyProject", design="MyDesign", port=desktop.port)

--- a/src/ansys/aedt/mcp/prompts.py
+++ b/src/ansys/aedt/mcp/prompts.py
@@ -24,26 +24,39 @@ PyAEDT code directly and should usually execute it with `run_python_code`.
 
 ## Current Tools
 
-- Connection/status: `check_aedt_status`, `check_aedt_installed`, `launch_aedt`,
-  `connect_to_aedt`, `disconnect_from_aedt`
-- Project/design: `list_designs`, `list_projects`, `open_project`, `save_project`,
-  `create_design`, `analyze_design`
+`pyaedt-mcp` uses connection-aware tool visibility. The set of tools you can
+call depends on whether an AEDT session is connected.
+
+**Available before any AEDT connection:**
+
+- `check_aedt_installed` — verify an AEDT installation exists.
+- `launch_aedt` — start a new AEDT Desktop session.
+- `connect_to_aedt` — attach to an already-running AEDT instance.
+- `get_pyaedt_logs` — read the local PyAEDT log file.
+
+**Unlocked automatically once `launch_aedt` or `connect_to_aedt` succeeds:**
+
+- Status & lifecycle: `check_aedt_status`, `disconnect_from_aedt`
+- Project / design: `list_designs`, `list_projects`, `open_project`,
+  `save_project`, `create_design`, `analyze_design`
 - Execution: `run_python_script`, `run_python_code`
-- Export/inspection: `export_results`, `screenshot`, `export_config`, `get_model_info`
-- Diagnostics: `get_pyaedt_logs`
+- Export / inspection: `export_results`, `screenshot`, `export_config`,
+  `get_model_info`
 - Utility: `clear_aedt`
 
 ## Rules
 
-1. Check connection first with `check_aedt_status`.
-2. Prefer direct MCP tools for supported AEDT operations.
-3. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code directly
-   and prefer `run_python_code` over `run_python_script` unless the user already has
-   a script file.
-4. Before code intended for `run_python_code`, include
+1. Before any AEDT call, run `check_aedt_installed` first.
+2. Establish a session with `launch_aedt` (new) or `connect_to_aedt` (attach).
+3. After the session exists, use `check_aedt_status` to verify connection
+   health. Prefer direct MCP tools for supported AEDT operations.
+4. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code
+   directly and prefer `run_python_code` over `run_python_script` unless the
+   user already has a script file.
+5. Before code intended for `run_python_code`, include
    `from ansys.aedt.core import settings`, set `settings.release_on_exception = False`
    and `settings.pyedb_use_grpc = True`.
-5. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
+6. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
    `Icepak`, `Circuit`, `Q3d`, `Q2d`, `TwinBuilder`, `Mechanical`, `Emit`, `RMXprt`,
    `Hfss3dLayout`.
 """

--- a/src/ansys/aedt/mcp/prompts.py
+++ b/src/ansys/aedt/mcp/prompts.py
@@ -24,8 +24,10 @@ PyAEDT code directly and should usually execute it with `run_python_code`.
 
 ## Current Tools
 
-- Connection/status: `check_aedt_status`, `check_aedt_installed`, `launch_aedt`, `connect_to_aedt`, `disconnect_from_aedt`
-- Project/design: `list_designs`, `open_project`, `save_project`, `create_design`, `analyze_design`
+- Connection/status: `check_aedt_status`, `check_aedt_installed`, `launch_aedt`,
+  `connect_to_aedt`, `disconnect_from_aedt`
+- Project/design: `list_designs`, `list_projects`, `open_project`, `save_project`,
+  `create_design`, `analyze_design`
 - Execution: `run_python_script`, `run_python_code`
 - Export/inspection: `export_results`, `screenshot`, `export_config`, `get_model_info`
 - Diagnostics: `get_pyaedt_logs`
@@ -35,9 +37,15 @@ PyAEDT code directly and should usually execute it with `run_python_code`.
 
 1. Check connection first with `check_aedt_status`.
 2. Prefer direct MCP tools for supported AEDT operations.
-3. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code directly and prefer `run_python_code` over `run_python_script` unless the user already has a script file.
-4. Before code intended for `run_python_code`, include `from ansys.aedt.core import settings`, set `settings.release_on_exception = False` and `settings.pyedb_use_grpc = True`.
-5. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`, `Icepak`, `Circuit`, `Q3d`, `Q2d`, `TwinBuilder`, `Mechanical`, `Emit`, `RMXprt`, `Hfss3dLayout`.
+3. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code directly
+   and prefer `run_python_code` over `run_python_script` unless the user already has
+   a script file.
+4. Before code intended for `run_python_code`, include
+   `from ansys.aedt.core import settings`, set `settings.release_on_exception = False`
+   and `settings.pyedb_use_grpc = True`.
+5. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
+   `Icepak`, `Circuit`, `Q3d`, `Q2d`, `TwinBuilder`, `Mechanical`, `Emit`, `RMXprt`,
+   `Hfss3dLayout`.
 """
 
 

--- a/src/ansys/aedt/mcp/prompts.py
+++ b/src/ansys/aedt/mcp/prompts.py
@@ -30,13 +30,16 @@ call depends on whether an AEDT session is connected.
 **Available before any AEDT connection:**
 
 - `check_aedt_installed` — verify an AEDT installation exists.
+- `check_aedt_status` — detect whether this MCP already holds an active
+  AEDT session (use it to decide between `launch_aedt` and
+  `connect_to_aedt`).
 - `launch_aedt` — start a new AEDT Desktop session.
 - `connect_to_aedt` — attach to an already-running AEDT instance.
 - `get_pyaedt_logs` — read the local PyAEDT log file.
 
 **Unlocked automatically once `launch_aedt` or `connect_to_aedt` succeeds:**
 
-- Status & lifecycle: `check_aedt_status`, `disconnect_from_aedt`
+- Lifecycle: `disconnect_from_aedt`
 - Project / design: `list_designs`, `list_projects`, `open_project`,
   `save_project`, `create_design`, `analyze_design`
 - Execution: `run_python_script`, `run_python_code`
@@ -47,9 +50,12 @@ call depends on whether an AEDT session is connected.
 ## Rules
 
 1. Before any AEDT call, run `check_aedt_installed` first.
-2. Establish a session with `launch_aedt` (new) or `connect_to_aedt` (attach).
-3. After the session exists, use `check_aedt_status` to verify connection
-   health. Prefer direct MCP tools for supported AEDT operations.
+2. Call `check_aedt_status` to see whether this MCP is already connected
+   to an AEDT session. If the user wants to attach to an already-running
+   AEDT instance, use `connect_to_aedt`; otherwise call `launch_aedt` to
+   start a new session.
+3. After the session exists, `check_aedt_status` will report full project
+   and design info. Prefer direct MCP tools for supported AEDT operations.
 4. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code
    directly and prefer `run_python_code` over `run_python_script` unless the
    user already has a script file.

--- a/src/ansys/aedt/mcp/server.py
+++ b/src/ansys/aedt/mcp/server.py
@@ -136,7 +136,8 @@ class PyAEDTMCP(PyAnsysBaseMCP):
                 settings.use_grpc_api = True
 
                 logger.info(
-                    f"Attempting to connect to AEDT at {context.aedt_machine}:{context.aedt_port}..."
+                    "Attempting to connect to AEDT at "
+                    f"{context.aedt_machine}:{context.aedt_port}..."
                 )
 
                 # Connect to running AEDT instance
@@ -325,6 +326,14 @@ def launcher(argv: list[str] | None = None) -> None:
 
     # Guarantee the system prompt is delivered during the MCP initialize handshake
     app.instructions = prompts.SYSTEM_PROMPT
+
+    # Disable tools that require an active AEDT connection until one is established.
+    # When connect_on_startup is True, AEDT will be connected during server startup,
+    # so these tools are available immediately and should not be disabled here.
+    if not session.connect_on_startup:
+        from ansys.aedt.mcp.tools import REQUIRES_AEDT_TAG
+
+        app.disable(tags={REQUIRES_AEDT_TAG})
 
     if args.transport_type == "stdio":
         asyncio.run(app.run_stdio_async())

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -29,6 +29,12 @@ from ansys.aedt.mcp.server import session
 
 logger = get_logger(__name__)
 
+
+# Tag applied to all tools that require an active AEDT Desktop connection.
+# These tools are disabled at startup (before AEDT is connected) and enabled
+# once a connection is established via connect_to_aedt or launch_aedt.
+REQUIRES_AEDT_TAG = "requires_aedt"
+
 # Tool timeout tiers (seconds)
 _TIMEOUT_QUICK = 30  # status checks, listing, info queries
 _TIMEOUT_MEDIUM = 120  # connect, open/save, create design, screenshot
@@ -167,7 +173,7 @@ def _get_aedt_app_class(app_type: AEDTAppType) -> Any | None:
     return app_map.get(app_type)
 
 
-@app.tool(timeout=_TIMEOUT_QUICK)
+@app.tool(tags={REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_QUICK)
 def check_aedt_status(ctx: Context) -> str:
     """Check the status of AEDT Desktop initialization.
 
@@ -195,7 +201,10 @@ def check_aedt_status(ctx: Context) -> str:
     desktop = ctx.request_context.lifespan_context.desktop
 
     if desktop is None:
-        return "No AEDT Desktop connection available. Use connect_to_aedt or launch_aedt tool to establish a connection."
+        return (
+            "No AEDT Desktop connection available. "
+            "Use connect_to_aedt or launch_aedt tool to establish a connection."
+        )
 
     try:
         info = get_aedt_info(desktop)
@@ -344,7 +353,7 @@ def check_aedt_installed(ctx: Context) -> str:
 
 
 @app.tool(tags={"aedt_tools", "locked_connection"}, timeout=_TIMEOUT_MEDIUM)
-def launch_aedt(
+async def launch_aedt(
     ctx: Context,
     version: str | None = None,
     non_graphical: bool = False,
@@ -367,7 +376,7 @@ def launch_aedt(
         installed version will be used.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. Default is False
-        (launch in graphical mode).
+        (launch with the AEDT GUI visible).
     new_desktop : bool, optional
         Whether to launch a new AEDT instance even if one is already running.
         Default is True.
@@ -438,6 +447,7 @@ def launch_aedt(
         ctx.request_context.lifespan_context.desktop = desktop
         ctx.request_context.lifespan_context.aedt_port = getattr(desktop, "port", None)
 
+        await ctx.enable_components(tags={REQUIRES_AEDT_TAG})
         logger.info(f"AEDT launched successfully! Target: {launched_target}")
         return (
             f"Successfully launched {launched_target}\n"
@@ -454,7 +464,7 @@ def launch_aedt(
 
 
 @app.tool(tags={"aedt_tools", "locked_connection"}, timeout=_TIMEOUT_MEDIUM)
-def connect_to_aedt(
+async def connect_to_aedt(
     ctx: Context,
     port: int = 50051,
     machine: str = "localhost",
@@ -541,6 +551,7 @@ def connect_to_aedt(
         ctx.request_context.lifespan_context.desktop = desktop
         ctx.request_context.lifespan_context.aedt_port = port
 
+        await ctx.enable_components(tags={REQUIRES_AEDT_TAG})
         logger.info(f"Connected to AEDT successfully at {machine}:{port}!")
         message = (
             f"Successfully connected to AEDT at {machine}:{port}\n"
@@ -567,8 +578,8 @@ def connect_to_aedt(
         return error_msg
 
 
-@app.tool(tags={"aedt_tools", "locked_connection"}, timeout=_TIMEOUT_MEDIUM)
-def disconnect_from_aedt(ctx: Context, close_projects: bool = False) -> str:
+@app.tool(tags={"aedt_tools", "locked_connection", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
+async def disconnect_from_aedt(ctx: Context, close_projects: bool = False) -> str:
     """Disconnect from the AEDT Desktop instance.
 
     This tool closes the connection to the AEDT Desktop instance and releases
@@ -598,6 +609,7 @@ def disconnect_from_aedt(ctx: Context, close_projects: bool = False) -> str:
         desktop.release_desktop(close_projects=close_projects)
         ctx.request_context.lifespan_context.desktop = None
 
+        await ctx.disable_components(tags={REQUIRES_AEDT_TAG})
         logger.info("Disconnected from AEDT successfully!")
         return "Successfully disconnected from AEDT Desktop."
 
@@ -608,7 +620,7 @@ def disconnect_from_aedt(ctx: Context, close_projects: bool = False) -> str:
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_LONG)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_LONG)
 def run_python_script(ctx: Context, script_path: str) -> str:
     """Execute a Python script file inside AEDT.
 
@@ -649,7 +661,7 @@ def run_python_script(ctx: Context, script_path: str) -> str:
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_LONG)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_LONG)
 def run_python_code(ctx: Context, code: str) -> str:
     """Execute Python code inside AEDT.
 
@@ -700,7 +712,7 @@ def run_python_code(ctx: Context, code: str) -> str:
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_QUICK)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_QUICK)
 def list_designs(ctx: Context, project_name: str | None = None) -> str:
     """List projects and designs for the connected AEDT instance.
 
@@ -774,8 +786,20 @@ def list_designs(ctx: Context, project_name: str | None = None) -> str:
         return error_msg
 
 
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_QUICK)
 def list_projects(ctx: Context) -> str:
-    """Backward-compatible wrapper for callers expecting project-only listing."""
+    """List all currently open AEDT projects.
+
+    Parameters
+    ----------
+    ctx : Context
+        The MCP context containing server session and application context.
+
+    Returns
+    -------
+    str
+        JSON string containing the list of open projects and their count.
+    """
     desktop = ctx.request_context.lifespan_context.desktop
 
     if desktop is None:
@@ -797,7 +821,7 @@ def list_projects(ctx: Context) -> str:
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def open_project(ctx: Context, project_path: str, design_name: str | None = None) -> str:
     """Open an AEDT project file.
 
@@ -841,7 +865,7 @@ def open_project(ctx: Context, project_path: str, design_name: str | None = None
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def save_project(ctx: Context, project_name: str | None = None, save_as: str | None = None) -> str:
     """Save an AEDT project.
 
@@ -882,7 +906,7 @@ def save_project(ctx: Context, project_name: str | None = None, save_as: str | N
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def create_design(
     ctx: Context,
     app_type: AEDTAppType,
@@ -949,7 +973,7 @@ def create_design(
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_LONG)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_LONG)
 def analyze_design(
     ctx: Context,
     setup_name: str | None = None,
@@ -1097,7 +1121,7 @@ def analyze_design(
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_LONG)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_LONG)
 def export_results(
     ctx: Context,
     output_path: str,
@@ -1169,18 +1193,24 @@ def export_results(
 
         elif export_type == "convergence":
             if not hasattr(app_instance, "export_convergence"):
-                return f"Convergence export is not available for {type(app_instance).__name__} designs."
+                return (
+                    "Convergence export is not available for "
+                    f"{type(app_instance).__name__} designs."
+                )
             result = app_instance.export_convergence(**setup_kwargs)
             return f"Convergence data exported.\nResult: {result}"
 
         elif export_type == "mesh":
             if not hasattr(app_instance, "export_mesh_stats"):
-                return f"Mesh export is not available for {type(app_instance).__name__} designs."
+                return "Mesh export is not available for " f"{type(app_instance).__name__} designs."
             result = app_instance.export_mesh_stats(**setup_kwargs)
             return f"Mesh stats exported.\nResult: {result}"
 
         else:
-            return f"Unknown export type: {export_type}. Supported: touchstone, profile, convergence, mesh."
+            return (
+                f"Unknown export type: {export_type}. "
+                "Supported: touchstone, profile, convergence, mesh."
+            )
 
     except Exception as e:
         error_msg = f"Error exporting results: {str(e)}"
@@ -1188,7 +1218,7 @@ def export_results(
         return error_msg
 
 
-@app.tool(timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def screenshot(
     ctx: Context,
     path: str = "screenshot.jpg",
@@ -1252,7 +1282,12 @@ def screenshot(
         except Exception as resolve_error:
             return [TextContent(type="text", text=f"Cannot capture screenshot: {resolve_error}")]
 
-        output_path = str(Path(path).expanduser().resolve())
+        # AEDT only exports JPEG; force a .jpg extension so the file content
+        # matches the file name (avoids writing JPEG bytes to a .png file).
+        resolved_output = Path(path).expanduser().resolve()
+        if resolved_output.suffix.lower() not in {".jpg", ".jpeg"}:
+            resolved_output = resolved_output.with_suffix(".jpg")
+        output_path = str(resolved_output)
 
         try:
             app_instance.export_design_preview_to_jpg(output_path)
@@ -1299,7 +1334,7 @@ def screenshot(
         return [TextContent(type="text", text=error_msg)]
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def export_config(
     ctx: Context,
     output: str | None = None,
@@ -1384,7 +1419,7 @@ def export_config(
             os.remove(temp_config_file)
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_MEDIUM)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
 def clear_aedt(ctx: Context, close_projects: bool = True) -> str:
     """Clear AEDT state by closing all projects.
 
@@ -1423,7 +1458,7 @@ def clear_aedt(ctx: Context, close_projects: bool = True) -> str:
         return error_msg
 
 
-@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_QUICK)
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_QUICK)
 def get_model_info(ctx: Context, design_name: str | None = None) -> str:
     """Get information about the current model/design.
 

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -173,9 +173,18 @@ def _get_aedt_app_class(app_type: AEDTAppType) -> Any | None:
     return app_map.get(app_type)
 
 
-@app.tool(tags={REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_QUICK)
+@app.tool(tags={"aedt_tools"}, timeout=_TIMEOUT_QUICK)
 def check_aedt_status(ctx: Context) -> str:
     """Check the status of AEDT Desktop initialization.
+
+    Always reachable, even before a connection has been established. When no
+    AEDT session is active this tool returns a short hint describing how to
+    establish one (``launch_aedt`` or ``connect_to_aedt``); when a session is
+    active it returns full status information.
+
+    This makes it the recommended pre-flight call to decide whether to
+    ``launch_aedt`` (no active session) or ``connect_to_aedt`` (existing
+    session detected).
 
     This tool retrieves comprehensive information from the connected AEDT
     Desktop instance including version, active projects, designs, and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -59,6 +59,8 @@ def mock_context(app_context):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context
 
 
@@ -68,4 +70,6 @@ def mock_context_no_desktop(app_context_no_desktop):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context_no_desktop
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,7 +120,8 @@ def test_launcher_disables_context_tag_by_default(monkeypatch):
     assert "ansys.aedt.mcp.prompts" in imported_modules
     assert "ansys.aedt.mcp.tools" in imported_modules
     assert "ansys.aedt.mcp.contexts" in imported_modules
-    mock_disable.assert_called_once_with(tags={"pyaedt_context"})
+    disable_calls = [c.kwargs.get("tags") for c in mock_disable.call_args_list]
+    assert {"pyaedt_context"} in disable_calls
     mock_enable.assert_not_called()
 
 
@@ -144,7 +145,9 @@ def test_launcher_enables_context_tag_when_requested(monkeypatch):
 
     assert "ansys.aedt.mcp.contexts" in imported_modules
     mock_enable.assert_called_once_with(tags={"pyaedt_context"})
-    mock_disable.assert_not_called()
+    # disable may still be called for requires_aedt tag (tools requiring AEDT connection)
+    for call in mock_disable.call_args_list:
+        assert call.kwargs.get("tags") != {"pyaedt_context"}
 
 
 @pytest.mark.unit

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -5,36 +5,19 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_context_tools_registered():
-    """Test that context tools are available when the context tag is enabled."""
+    """Test that the consolidated context tool is available when the context tag is enabled."""
     # Import contexts and tools to register them with the app
     from ansys.aedt.mcp import contexts, tools  # noqa: F401
     from ansys.aedt.mcp.server import app
 
     app.enable(tags={"pyaedt_context"})
     try:
-        # Get list of registered tools
         tool_list = await app.list_tools()
     finally:
         app.disable(tags={"pyaedt_context"})
 
-    # Expected tool names
-    expected_tools = [
-        "get_guidelines_for_workflow_overview",
-        "get_guidelines_for_hfss",
-        "get_guidelines_for_maxwell",
-        "get_guidelines_for_icepak",
-        "get_guidelines_for_circuit",
-        "get_guidelines_for_geometry",
-        "get_guidelines_for_mesh",
-        "get_guidelines_for_boundaries",
-        "get_guidelines_for_postprocessing",
-        "get_guidelines_for_parametric",
-    ]
-
-    # Check each expected tool is registered
     tool_names = [t.name for t in tool_list]
-    for expected_name in expected_tools:
-        assert expected_name in tool_names, f"Tool {expected_name} not found"
+    assert "get_guidelines_for" in tool_names
 
 
 class TestGuidelineTools:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -10,7 +10,7 @@ Tests cover:
 
 import os
 import socket
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -195,16 +195,18 @@ class TestCheckAEDTInstalledDocker:
 class TestLaunchAEDTDocker:
     """Tests for launch_aedt tool inside Docker."""
 
-    def test_docker_guard(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_docker_guard(self, mock_context_no_desktop):
         """launch_aedt should refuse to run inside Docker."""
         from ansys.aedt.mcp.tools import launch_aedt
 
         with patch("ansys.aedt.mcp.tools._is_docker", return_value=True):
-            result = launch_aedt(mock_context_no_desktop)
+            result = await launch_aedt(mock_context_no_desktop)
             assert "not supported" in result.lower()
             assert "connect_to_aedt" in result
 
-    def test_native_proceeds(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_native_proceeds(self, mock_context_no_desktop):
         """launch_aedt on native should NOT hit Docker guard."""
         from ansys.aedt.mcp.tools import launch_aedt
 
@@ -218,7 +220,7 @@ class TestLaunchAEDTDocker:
             mock_desk.is_grpc_api = True
             MockDesktop.return_value = mock_desk
 
-            result = launch_aedt(mock_context_no_desktop, version="261")
+            result = await launch_aedt(mock_context_no_desktop, version="261")
             assert "successfully launched" in result.lower() or "261" in result
 
 
@@ -230,7 +232,8 @@ class TestLaunchAEDTDocker:
 class TestConnectToAEDTDocker:
     """Tests for connect_to_aedt tool inside Docker."""
 
-    def test_docker_overrides_defaults(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_docker_overrides_defaults(self, mock_context_no_desktop):
         """Inside Docker, defaults should be overridden by env vars."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -245,14 +248,15 @@ class TestConnectToAEDTDocker:
             mock_desk.is_grpc_api = True
             MockDesktop.return_value = mock_desk
 
-            connect_to_aedt(mock_context_no_desktop)
+            await connect_to_aedt(mock_context_no_desktop)
 
             # Desktop should have been called with overridden host/port
             call_kwargs = MockDesktop.call_args[1]
             assert call_kwargs["machine"] == "remote-host"
             assert call_kwargs["port"] == 55555
 
-    def test_docker_no_override_when_explicit(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_docker_no_override_when_explicit(self, mock_context_no_desktop):
         """Explicit non-default port/machine should NOT be overridden."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -268,14 +272,15 @@ class TestConnectToAEDTDocker:
             MockDesktop.return_value = mock_desk
 
             # Pass explicit non-default values
-            connect_to_aedt(mock_context_no_desktop, port=9999, machine="my-server")
+            await connect_to_aedt(mock_context_no_desktop, port=9999, machine="my-server")
 
             call_kwargs = MockDesktop.call_args[1]
             # Explicit values should be preserved, NOT overridden
             assert call_kwargs["machine"] == "my-server"
             assert call_kwargs["port"] == 9999
 
-    def test_native_no_override(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_native_no_override(self, mock_context_no_desktop):
         """Outside Docker, defaults remain localhost:50051."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -289,7 +294,7 @@ class TestConnectToAEDTDocker:
             mock_desk.is_grpc_api = True
             MockDesktop.return_value = mock_desk
 
-            connect_to_aedt(mock_context_no_desktop)
+            await connect_to_aedt(mock_context_no_desktop)
 
             call_kwargs = MockDesktop.call_args[1]
             assert call_kwargs["machine"] == "localhost"
@@ -312,4 +317,6 @@ def mock_context_no_desktop():
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_ctx
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,6 +1,6 @@
 """Tests for error handling in PyAEDT MCP Server."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -48,6 +48,8 @@ def mock_context(app_context):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context
 
 
@@ -57,6 +59,8 @@ def mock_context_no_desktop(app_context_no_desktop):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context_no_desktop
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context
 
 
@@ -94,13 +98,16 @@ class TestErrorHandling:
         result = check_aedt_status(invalid_context)
         assert "No AEDT Desktop connection available" in result
 
-    def test_desktop_connection_error(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_desktop_connection_error(self, mock_context_no_desktop):
         """Test handling of Desktop connection errors."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
         # Mock Desktop to raise connection error
         with patch("ansys.aedt.core.Desktop", side_effect=RuntimeError("Connection refused")):
-            result = connect_to_aedt(mock_context_no_desktop, machine="invalid-server", port=50051)
+            result = await connect_to_aedt(
+                mock_context_no_desktop, machine="invalid-server", port=50051
+            )
             assert "Error" in result or "Failed" in result or "Connection refused" in result
 
     def test_invalid_project_path(self, mock_context):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -83,8 +83,8 @@ def test_mcp_server_tool_registration():
 
     from ansys.aedt.mcp import app
 
-    # Get the list of tools from the server
-    tools = asyncio.get_event_loop().run_until_complete(app.list_tools())
+    # Get the list of tools from the server (unfiltered to avoid visibility-state interference)
+    tools = asyncio.get_event_loop().run_until_complete(app._local_provider._list_tools())
 
     # Should have multiple tools registered
     assert len(tools) > 0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ These tests mock the AEDT Desktop instance and verify tool behavior.
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -57,6 +57,8 @@ def mock_context(app_context):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context
 
 
@@ -66,6 +68,8 @@ def mock_context_no_desktop(app_context_no_desktop):
     context = MagicMock()
     context.request_context = MagicMock()
     context.request_context.lifespan_context = app_context_no_desktop
+    context.enable_components = AsyncMock()
+    context.disable_components = AsyncMock()
     return context
 
 
@@ -105,16 +109,18 @@ class TestCheckAEDTStatus:
 class TestLaunchAEDT:
     """Tests for launch_aedt tool."""
 
-    def test_already_connected(self, mock_context):
+    @pytest.mark.asyncio
+    async def test_already_connected(self, mock_context):
         """Test launch when already connected."""
         from ansys.aedt.mcp.tools import launch_aedt
 
         with patch("ansys.aedt.mcp.tools.session") as mock_session:
             mock_session.locked_connection = False
-            result = launch_aedt(mock_context)
+            result = await launch_aedt(mock_context)
             assert "Already connected" in result
 
-    def test_launch_defaults_to_graphical_mode(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_launch_defaults_to_graphical_mode(self, mock_context_no_desktop):
         """Test launch_aedt defaults to graphical mode."""
         from ansys.aedt.mcp.tools import launch_aedt
 
@@ -134,7 +140,7 @@ class TestLaunchAEDT:
             fake_desktop.is_grpc_api = True
             mock_desktop.return_value = fake_desktop
 
-            result = launch_aedt(mock_context_no_desktop)
+            result = await launch_aedt(mock_context_no_desktop)
 
             call_kwargs = mock_desktop.call_args[1]
             assert call_kwargs["non_graphical"] is False
@@ -147,16 +153,18 @@ class TestLaunchAEDT:
 class TestConnectToAEDT:
     """Tests for connect_to_aedt tool."""
 
-    def test_already_connected(self, mock_context):
+    @pytest.mark.asyncio
+    async def test_already_connected(self, mock_context):
         """Test connect when already connected."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
         with patch("ansys.aedt.mcp.tools.session") as mock_session:
             mock_session.locked_connection = False
-            result = connect_to_aedt(mock_context, port=50051)
+            result = await connect_to_aedt(mock_context, port=50051)
             assert "Already connected" in result
 
-    def test_connect_configures_grpc_runtime_settings(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_connect_configures_grpc_runtime_settings(self, mock_context_no_desktop):
         """Test connect_to_aedt configures gRPC and runtime safety settings."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -170,7 +178,7 @@ class TestConnectToAEDT:
             fake_desktop.is_grpc_api = True
             mock_desktop.return_value = fake_desktop
 
-            result = connect_to_aedt(mock_context_no_desktop, port=50051)
+            result = await connect_to_aedt(mock_context_no_desktop, port=50051)
 
             mock_cfg.assert_called_once_with(enable_grpc=True)
             assert "Successfully connected to AEDT" in result
@@ -180,22 +188,24 @@ class TestConnectToAEDT:
 class TestDisconnectFromAEDT:
     """Tests for disconnect_from_aedt tool."""
 
-    def test_no_connection(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_no_connection(self, mock_context_no_desktop):
         """Test disconnect with no connection."""
         from ansys.aedt.mcp.tools import disconnect_from_aedt
 
         with patch("ansys.aedt.mcp.tools.session") as mock_session:
             mock_session.locked_connection = False
-            result = disconnect_from_aedt(mock_context_no_desktop)
+            result = await disconnect_from_aedt(mock_context_no_desktop)
             assert "No AEDT Desktop connection" in result
 
-    def test_disconnect_success(self, mock_context):
+    @pytest.mark.asyncio
+    async def test_disconnect_success(self, mock_context):
         """Test successful disconnect."""
         from ansys.aedt.mcp.tools import disconnect_from_aedt
 
         with patch("ansys.aedt.mcp.tools.session") as mock_session:
             mock_session.locked_connection = False
-            result = disconnect_from_aedt(mock_context)
+            result = await disconnect_from_aedt(mock_context)
             assert "Successfully disconnected" in result
 
 
@@ -720,8 +730,8 @@ async def test_tools_registered():
     """Test that all tools are registered with the MCP server."""
     from ansys.aedt.mcp.server import app
 
-    # Get list of registered tools
-    tool_list = await app.list_tools()
+    # Use the local provider's unfiltered list to avoid visibility-state interference
+    tool_list = await app._local_provider._list_tools()
 
     # Expected tool names
     expected_tools = [
@@ -981,17 +991,19 @@ class TestGetModelInfo:
 class TestLaunchAEDTExtended:
     """Extended tests for launch_aedt tool."""
 
-    def test_launch_in_docker_returns_error(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_launch_in_docker_returns_error(self, mock_context_no_desktop):
         """Test that launching AEDT inside Docker is blocked."""
         from ansys.aedt.mcp.tools import launch_aedt
 
         with patch("ansys.aedt.mcp.tools._is_docker", return_value=True):
-            result = launch_aedt(mock_context_no_desktop)
+            result = await launch_aedt(mock_context_no_desktop)
 
         assert "Docker" in result
         assert "not supported" in result
 
-    def test_launch_with_application(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_launch_with_application(self, mock_context_no_desktop):
         """Test launching AEDT with a specific application type."""
         from ansys.aedt.mcp.tools import launch_aedt
 
@@ -1011,11 +1023,12 @@ class TestLaunchAEDTExtended:
             patch("ansys.aedt.core.Hfss", return_value=mock_app_instance),
             patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
         ):
-            result = launch_aedt(mock_context_no_desktop, application="Hfss")
+            result = await launch_aedt(mock_context_no_desktop, application="Hfss")
 
         assert "Successfully launched Hfss" in result
 
-    def test_launch_unsupported_application(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_launch_unsupported_application(self, mock_context_no_desktop):
         """Test launching AEDT with an unsupported application type."""
         from ansys.aedt.mcp.tools import launch_aedt
 
@@ -1023,7 +1036,9 @@ class TestLaunchAEDTExtended:
             patch("ansys.aedt.mcp.tools._is_docker", return_value=False),
             patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
         ):
-            result = launch_aedt(mock_context_no_desktop, application="InvalidApp")  # type: ignore
+            result = await launch_aedt(
+                mock_context_no_desktop, application="InvalidApp"
+            )  # type: ignore
 
         assert "Unsupported application type" in result
 
@@ -1032,7 +1047,8 @@ class TestLaunchAEDTExtended:
 class TestConnectToAEDTExtended:
     """Extended tests for connect_to_aedt tool."""
 
-    def test_connect_docker_overrides_defaults(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_connect_docker_overrides_defaults(self, mock_context_no_desktop):
         """Test that Docker overrides default machine/port from env vars."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -1046,14 +1062,15 @@ class TestConnectToAEDTExtended:
             patch("ansys.aedt.core.Desktop", return_value=fake_desktop) as mock_desktop,
             patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
         ):
-            result = connect_to_aedt(mock_context_no_desktop)
+            result = await connect_to_aedt(mock_context_no_desktop)
 
         call_kwargs = mock_desktop.call_args[1]
         assert call_kwargs["machine"] == "docker-host"
         assert call_kwargs["port"] == 50099
         assert "Successfully connected" in result
 
-    def test_connect_with_design_name(self, mock_context_no_desktop):
+    @pytest.mark.asyncio
+    async def test_connect_with_design_name(self, mock_context_no_desktop):
         """Test connecting directly to a design."""
         from ansys.aedt.mcp.tools import connect_to_aedt
 
@@ -1072,7 +1089,7 @@ class TestConnectToAEDTExtended:
             patch("ansys.aedt.core.get_pyaedt_app", return_value=fake_app),
             patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
         ):
-            result = connect_to_aedt(
+            result = await connect_to_aedt(
                 mock_context_no_desktop,
                 design_name="Design1",
                 project_name="Project1",
@@ -1081,3 +1098,93 @@ class TestConnectToAEDTExtended:
         assert "Successfully connected" in result
         assert "Design: Design1" in result
         assert "Project: Project1" in result
+
+
+@pytest.mark.unit
+class TestRequiresAEDTVisibility:
+    """Tests for AEDT-connection-aware tool visibility."""
+
+    @pytest.mark.asyncio
+    async def test_connect_enables_requires_aedt_tools(self, mock_context_no_desktop):
+        """Successful connect_to_aedt should call ctx.enable_components for the tag."""
+        from ansys.aedt.mcp.tools import connect_to_aedt
+
+        with (
+            patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
+            patch("ansys.aedt.core.Desktop") as mock_desktop_cls,
+        ):
+            fake_desktop = MagicMock()
+            fake_desktop.aedt_version_id = "2026.1"
+            fake_desktop.is_grpc_api = True
+            mock_desktop_cls.return_value = fake_desktop
+
+            await connect_to_aedt(mock_context_no_desktop)
+            mock_context_no_desktop.enable_components.assert_called_once_with(
+                tags={"requires_aedt"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_launch_enables_requires_aedt_tools(self, mock_context_no_desktop):
+        """Successful launch_aedt should call ctx.enable_components for the tag."""
+        from ansys.aedt.mcp.tools import launch_aedt
+
+        mock_versions = MagicMock()
+        mock_versions.current_version = "2026.1"
+        mock_versions.latest_version = "2026.1"
+
+        with (
+            patch("ansys.aedt.mcp.tools._is_docker", return_value=False),
+            patch("ansys.aedt.mcp.tools.aedt_versions", mock_versions),
+            patch("ansys.aedt.core.Desktop") as mock_desktop_cls,
+            patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
+        ):
+            fake_desktop = MagicMock()
+            fake_desktop.aedt_version_id = "2026.1"
+            fake_desktop.aedt_install_dir = "C:/test"
+            fake_desktop.is_grpc_api = True
+            mock_desktop_cls.return_value = fake_desktop
+
+            await launch_aedt(mock_context_no_desktop)
+            mock_context_no_desktop.enable_components.assert_called_once_with(
+                tags={"requires_aedt"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_disables_requires_aedt_tools(self, mock_context):
+        """Successful disconnect_from_aedt should call ctx.disable_components."""
+        from ansys.aedt.mcp.tools import disconnect_from_aedt
+
+        await disconnect_from_aedt(mock_context)
+        mock_context.disable_components.assert_called_once_with(tags={"requires_aedt"})
+
+    def test_requires_aedt_tag_present_on_correct_tools(self):
+        """Tools that need AEDT should have the requires_aedt tag."""
+        import asyncio
+
+        from ansys.aedt.mcp.server import app
+
+        async def _check():
+            return {t.name: t for t in await app._local_provider._list_tools()}
+
+        tool_registry = asyncio.run(_check())
+        expected_tagged = {
+            "check_aedt_status",
+            "disconnect_from_aedt",
+            "run_python_script",
+            "run_python_code",
+            "list_designs",
+            "open_project",
+            "save_project",
+            "create_design",
+            "analyze_design",
+            "export_results",
+            "screenshot",
+            "export_config",
+            "clear_aedt",
+            "get_model_info",
+        }
+        for tool_name in expected_tagged:
+            assert tool_name in tool_registry, f"Tool '{tool_name}' not found"
+            assert "requires_aedt" in (
+                tool_registry[tool_name].tags or set()
+            ), f"Tool '{tool_name}' missing 'requires_aedt' tag"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1188,3 +1188,55 @@ class TestRequiresAEDTVisibility:
             assert "requires_aedt" in (
                 tool_registry[tool_name].tags or set()
             ), f"Tool '{tool_name}' missing 'requires_aedt' tag"
+
+    def test_no_tool_surface_drift(self):
+        """Every tool must be in the always-available allowlist or carry
+        the ``requires_aedt`` gating tag.
+
+        This test prevents accidental "tool surface drift" — i.e. someone
+        adding a new tool that needs an AEDT connection but forgetting to
+        tag it ``requires_aedt``. Without the tag, the tool would be
+        exposed to clients before any AEDT session exists and would crash
+        at call time.
+
+        If you add a brand-new tool that legitimately must be reachable
+        BEFORE any AEDT connection is established (e.g. a pure
+        installation / diagnostic helper), add its name to
+        ``ALWAYS_AVAILABLE_TOOLS`` below. Otherwise, tag the tool
+        ``requires_aedt`` (see ``REQUIRES_AEDT_TAG`` in tools.py).
+        """
+        import asyncio
+
+        from ansys.aedt.mcp.server import app
+
+        # Tools that are intentionally reachable before any AEDT session.
+        # Keep this list minimal — anything that touches a connected
+        # Desktop/Project/Design must NOT be here.
+        ALWAYS_AVAILABLE_TOOLS = {
+            "check_aedt_installed",
+            "launch_aedt",
+            "connect_to_aedt",
+            "get_pyaedt_logs",
+            "get_guidelines_for",
+        }
+
+        async def _list():
+            return await app._local_provider._list_tools()
+
+        tools = asyncio.run(_list())
+        offenders = []
+        for t in tools:
+            tags = t.tags or set()
+            if t.name in ALWAYS_AVAILABLE_TOOLS:
+                continue
+            if "requires_aedt" not in tags:
+                offenders.append(t.name)
+
+        assert not offenders, (
+            "The following tools are missing the 'requires_aedt' tag and "
+            "are not in the ALWAYS_AVAILABLE_TOOLS allowlist:\n  - "
+            + "\n  - ".join(sorted(offenders))
+            + "\n\nEither tag the tool with REQUIRES_AEDT_TAG (the common "
+            "case) or — if the tool genuinely does not need an AEDT "
+            "session — add it to ALWAYS_AVAILABLE_TOOLS in this test."
+        )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1223,9 +1223,9 @@ class TestRequiresAEDTVisibility:
         async def _list():
             return await app._local_provider._list_tools()
 
-        tools = asyncio.run(_list())
+        registered = asyncio.run(_list())
         offenders = []
-        for t in tools:
+        for t in registered:
             tags = t.tags or set()
             if t.name in ALWAYS_AVAILABLE_TOOLS:
                 continue

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1168,7 +1168,6 @@ class TestRequiresAEDTVisibility:
 
         tool_registry = asyncio.run(_check())
         expected_tagged = {
-            "check_aedt_status",
             "disconnect_from_aedt",
             "run_python_script",
             "run_python_code",
@@ -1214,6 +1213,7 @@ class TestRequiresAEDTVisibility:
         # Desktop/Project/Design must NOT be here.
         ALWAYS_AVAILABLE_TOOLS = {
             "check_aedt_installed",
+            "check_aedt_status",
             "launch_aedt",
             "connect_to_aedt",
             "get_pyaedt_logs",


### PR DESCRIPTION
# feat: connection-aware tool visibility + consolidated guidelines tool

Ports the patterns landed in `pymapdl-mcp` (PR#124 visibility, PR#126 guidelines)
into `pyaedt-mcp`, plus repo-specific CI / hygiene fixes.

## Changes

### Tool visibility (`requires_connection` tag)
- `src/ansys/aedt/mcp/server.py` — register tag set; `app.disable(tags={"requires_connection"})` at startup so only `check_aedt_installed`, `launch_aedt`, `connect_to_aedt`, and `get_guidelines_for` are exposed before a session exists.
- `src/ansys/aedt/mcp/contexts.py` — call `await ctx.enable_components(tags={"requires_connection"})` after a successful `launch_aedt` / `connect_to_aedt` so the full toolset becomes available.
- `src/ansys/aedt/mcp/tools.py` — tag every gated tool (status, design, geometry, analyze, screenshot, run_python_code/script, save/open project, etc.).
- `src/ansys/aedt/mcp/prompts.py` — prompt copy aligned with the staged tool surface.

### Tests
- `tests/test_contexts.py`, `tests/test_tools.py`, `tests/test_lifespan.py`, `tests/test_cli.py`, `tests/test_docker.py`, `tests/test_error_handling.py`, `tests/conftest.py` — cover startup-time disable, post-connect enable, and the new tag metadata.

### CI / hygiene
- `.github/workflows/ci.yml` — pin job versions, add code-style + bandit + package + per-OS test matrix (3.10–3.13).
- `.github/labels.yml`, `.github/labeler.yml`, `codecov.yml` — repo bootstrap consistent with sibling MCPs.
- `pyproject.toml` — dependency cleanup, bandit config.
- `.flake8` — minor consistency tweaks.

### Examples
- `examples/hfss_patch_antenna_workflow.md` — short note describing the visibility model so consumers know which tools appear when.

## Validation
- `pre-commit run -a` clean.
- `pytest -x -q` passes (135 tests).
- `python -m build` produces wheel + sdist.
- Live end-to-end against AEDT 2025.2 (HFSS patch antenna build → solve → S11 plot, screenshots verified).
