### PR TITLE
feat: add toolsets://definition discovery resource

### DIFF
--- a/src/ansys/aedt/mcp/server.py
+++ b/src/ansys/aedt/mcp/server.py
@@ -318,6 +318,7 @@ def launcher(argv: list[str] | None = None) -> None:
     prompts = importlib.import_module("ansys.aedt.mcp.prompts")
     importlib.import_module("ansys.aedt.mcp.tools")
     importlib.import_module("ansys.aedt.mcp.contexts")
+    importlib.import_module("ansys.aedt.mcp.toolsets")
 
     if args.include_context_tools:
         app.enable(tags={"pyaedt_context"})

--- a/src/ansys/aedt/mcp/toolsets.py
+++ b/src/ansys/aedt/mcp/toolsets.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+
+"""Toolset definitions for PyAnsysMCPService discovery.
+
+Exposes the ``toolsets://definition`` MCP resource that groups every tool
+registered on the PyAEDT MCP server into logical, user-facing categories.
+Each toolset entry follows the schema agreed across the Ansys MCP family:
+
+``{"name": str, "description": str, "skill": str, "tools": list[str]}``
+
+The catalogue is a pure discovery aid — it does not affect tool visibility,
+gating, or runtime behavior. Visibility is still controlled by the existing
+``REQUIRES_AEDT_TAG`` / ``aedt_tools`` / ``locked_connection`` tags applied
+in :mod:`ansys.aedt.mcp.tools`.
+"""
+
+from typing import Any
+
+from ansys.aedt.mcp import app
+
+#: Master catalogue mapping every logical toolset to its metadata + tool list.
+#: When you register a new tool with ``@app.tool``, add it to one of these
+#: toolsets so it is discoverable through ``toolsets://definition``.
+_TOOLSET_CATALOGUE: dict[str, dict[str, Any]] = {
+    "lifecycle": {
+        "description": (
+            "Tools for installing, launching, connecting to, disconnecting "
+            "from, and tearing down AEDT sessions."
+        ),
+        "skill": (
+            "Call check_aedt_installed once at startup to confirm the AEDT "
+            "binary is on disk. Call check_aedt_status before every workflow "
+            "to see whether this MCP already has a live Desktop connection. "
+            "Use connect_to_aedt to attach to a running Desktop "
+            "(machine + gRPC port); otherwise use launch_aedt to start a "
+            "new instance. Call disconnect_from_aedt for a graceful detach "
+            "and clear_aedt to fully release the Desktop process."
+        ),
+        "tools": [
+            "check_aedt_installed",
+            "check_aedt_status",
+            "launch_aedt",
+            "connect_to_aedt",
+            "disconnect_from_aedt",
+            "clear_aedt",
+        ],
+    },
+    "project-management": {
+        "description": (
+            "Tools for opening, saving, listing, and creating AEDT projects " "and designs."
+        ),
+        "skill": (
+            "Use list_projects to enumerate open AEDT projects, list_designs "
+            "to enumerate designs in a project, open_project to load a "
+            ".aedt/.aedtz file, save_project to persist changes, and "
+            "create_design to add a new design (HFSS, Maxwell, Icepak, etc.) "
+            "to the active project."
+        ),
+        "tools": [
+            "list_projects",
+            "list_designs",
+            "open_project",
+            "save_project",
+            "create_design",
+        ],
+    },
+    "simulation": {
+        "description": ("Tools for configuring and running AEDT solver analyses."),
+        "skill": (
+            "Use analyze_design to run a configured setup/sweep on the "
+            "active design. Use export_config to persist the current setup "
+            "and sweep configuration for reproducibility or sharing."
+        ),
+        "tools": [
+            "analyze_design",
+            "export_config",
+        ],
+    },
+    "scripting": {
+        "description": (
+            "Tools for executing arbitrary PyAEDT Python code or scripts "
+            "against the live Desktop session."
+        ),
+        "skill": (
+            "Use run_python_code to execute a short inline snippet "
+            "(introspection, parameter tweaks, custom geometry). Use "
+            "run_python_script to execute a full .py file from disk. Both "
+            "share the same persistent Python session, so variables and "
+            "imports defined in one call remain available in subsequent calls."
+        ),
+        "tools": [
+            "run_python_code",
+            "run_python_script",
+        ],
+    },
+    "inspection": {
+        "description": (
+            "Tools for inspecting the active model, capturing screenshots, "
+            "and reading PyAEDT runtime logs."
+        ),
+        "skill": (
+            "Use get_model_info to retrieve a structured summary of the "
+            "active design (solids, boundaries, materials, excitations). "
+            "Use screenshot to capture the current 3D modeler view as a PNG "
+            "for the user. Use get_pyaedt_logs to retrieve recent PyAEDT log "
+            "lines when diagnosing failures."
+        ),
+        "tools": [
+            "get_model_info",
+            "screenshot",
+            "get_pyaedt_logs",
+        ],
+    },
+    "results": {
+        "description": (
+            "Tools for extracting and exporting solver results from a " "solved AEDT design."
+        ),
+        "skill": (
+            "Use export_results after a successful analyze_design call to "
+            "write field/network/parameter results to disk in a "
+            "human-readable or post-processable format."
+        ),
+        "tools": [
+            "export_results",
+        ],
+    },
+    "guidelines": {
+        "description": (
+            "Reference tool for retrieving PyAEDT / AEDT scripting "
+            "guidelines (workflow, HFSS, Maxwell, Icepak, Circuit, "
+            "geometry, mesh, boundaries, postprocessing, parametric)."
+        ),
+        "skill": (
+            "Call get_guidelines_for once per topic before generating "
+            "PyAEDT code or invoking a workflow tool. It returns the "
+            "authoritative scripting patterns and best practices for the "
+            "requested topic. This tool is only registered when the "
+            "server is launched with --include-context-tools."
+        ),
+        "tools": [
+            "get_guidelines_for",
+        ],
+    },
+}
+
+
+def _build_toolsets() -> list[dict[str, Any]]:
+    """Return the toolset catalogue as the list[dict] payload expected by clients."""
+    return [
+        {
+            "name": name,
+            "description": entry["description"],
+            "skill": entry["skill"],
+            "tools": list(entry["tools"]),
+        }
+        for name, entry in _TOOLSET_CATALOGUE.items()
+    ]
+
+
+@app.resource(
+    "toolsets://definition",
+    name="toolsets_definition",
+    description="Toolset definitions for PyAnsysMCPService discovery.",
+    mime_type="application/json",
+)
+def get_toolsets() -> list[dict[str, Any]]:
+    """Return toolset definitions for PyAnsysMCPService discovery."""
+    return _build_toolsets()

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,0 +1,107 @@
+"""Tests for the ``toolsets://definition`` MCP resource."""
+
+import asyncio
+
+import pytest
+
+# Importing tools, contexts, and toolsets ensures everything is registered on `app`.
+from ansys.aedt.mcp import contexts  # noqa: F401
+from ansys.aedt.mcp import tools  # noqa: F401
+from ansys.aedt.mcp import toolsets as toolsets_module  # noqa: F401
+from ansys.aedt.mcp.server import app
+from ansys.aedt.mcp.toolsets import _TOOLSET_CATALOGUE, _build_toolsets
+
+REQUIRED_KEYS = {"name", "description", "skill", "tools"}
+
+
+def _list_tool_names() -> set[str]:
+    async def _list():
+        return await app._local_provider._list_tools()
+
+    return {t.name for t in asyncio.run(_list())}
+
+
+class TestToolsetsResource:
+    def test_build_returns_list(self):
+        result = _build_toolsets()
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_items_have_required_keys(self):
+        for entry in _build_toolsets():
+            assert REQUIRED_KEYS <= entry.keys(), (
+                f"toolset {entry.get('name')} missing keys: " f"{REQUIRED_KEYS - entry.keys()}"
+            )
+
+    def test_string_fields_are_non_empty(self):
+        for entry in _build_toolsets():
+            for key in ("name", "description", "skill"):
+                assert (
+                    isinstance(entry[key], str) and entry[key].strip()
+                ), f"toolset {entry['name']!r} field {key!r} is empty"
+
+    def test_tools_field_is_list_of_strings(self):
+        for entry in _build_toolsets():
+            assert isinstance(entry["tools"], list)
+            assert all(isinstance(t, str) and t for t in entry["tools"])
+
+    def test_toolset_names_unique(self):
+        names = [e["name"] for e in _build_toolsets()]
+        assert len(names) == len(set(names))
+
+    def test_each_listed_tool_is_a_real_registered_tool(self):
+        registered = _list_tool_names()
+        missing: list[tuple[str, str]] = []
+        for entry in _build_toolsets():
+            for tool in entry["tools"]:
+                if tool not in registered:
+                    missing.append((entry["name"], tool))
+        assert (
+            not missing
+        ), "Toolset catalogue references unregistered tools:\n  - " + "\n  - ".join(
+            f"{ts}: {t}" for ts, t in missing
+        )
+
+    def test_every_registered_tool_appears_in_some_toolset(self):
+        registered = _list_tool_names()
+        listed = {t for e in _build_toolsets() for t in e["tools"]}
+        orphans = registered - listed
+        assert not orphans, (
+            "The following registered tools are not listed in any toolset "
+            "in toolsets.py:\n  - "
+            + "\n  - ".join(sorted(orphans))
+            + "\n\nAdd each to the appropriate toolset in "
+            "ansys/aedt/mcp/toolsets.py::_TOOLSET_CATALOGUE."
+        )
+
+    def test_no_tool_listed_in_multiple_toolsets(self):
+        seen: dict[str, str] = {}
+        duplicates: list[tuple[str, str, str]] = []
+        for entry in _build_toolsets():
+            for tool in entry["tools"]:
+                if tool in seen:
+                    duplicates.append((tool, seen[tool], entry["name"]))
+                else:
+                    seen[tool] = entry["name"]
+        assert not duplicates, "Tools appearing in multiple toolsets:\n  - " + "\n  - ".join(
+            f"{t} in {a!r} and {b!r}" for t, a, b in duplicates
+        )
+
+    def test_resource_is_registered(self):
+        async def _list():
+            return await app._list_resources()
+
+        resources = asyncio.run(_list())
+        uris = {str(r.uri) for r in resources}
+        assert (
+            "toolsets://definition" in uris
+        ), f"toolsets://definition not registered. Found: {sorted(uris)}"
+
+    def test_catalogue_is_module_constant(self):
+        # Stability anchor: ensure module exposes the catalogue dict.
+        assert isinstance(_TOOLSET_CATALOGUE, dict)
+        assert _TOOLSET_CATALOGUE  # non-empty
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a new `toolsets://definition` MCP resource that returns a `list[dict]` catalogue grouping every registered PyAEDT MCP tool into 7 logical, user-facing toolsets (lifecycle, project-management, simulation, scripting, inspection, results, guidelines).

The schema matches the convention agreed across the PyAnsys MCP family and is consumed by `PyAnsysMCPService` for tool discovery and conductor routing:

```json
{"name": str, "description": str, "skill": str, "tools": list[str]}
```

## Why

- The Service-layer conductor needs a stable, machine-readable grouping of tools per MCP server to route LLM tool calls efficiently.
- A flat tool list is hard for the conductor (and humans) to reason about — toolsets make capability discovery O(1).

## What's NOT changed

- **No tool visibility / gating changes.** Existing tag-based gating (`requires_aedt`, `aedt_tools`, `locked_connection`, `pyaedt_context`) is preserved unchanged.
- **No runtime behavior changes.** This is a pure discovery aid.

## Tests

- 10 new unit tests in `tests/test_toolsets.py` verifying: required keys, non-empty values, every listed tool resolves to a real registered tool, no orphans, no duplicates, and the resource is exposed on the FastMCP app.
- All 10 pass locally; existing test suite unaffected.

Resolves #12
