### PR TITLE
test: improve unit coverage for helpers/startup paths

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+ENV USERNAME=pyaedt
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ON_CODESPACES=false
+ENV ON_LOCAL=true
+ENV ON_UBUNTU=true
+ENV ON_CI=true
+
+RUN apt-get -qq update && apt-get -qq install -y \
+    gcc g++ \
+    python3-pip \
+    python3-venv \
+    git \
+    && apt-get -qq clean && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -s /bin/bash ${USERNAME} \
+    && usermod -a -G sudo ${USERNAME}
+
+RUN mkdir -p /home/${USERNAME}/pyaedt-mcp
+
+WORKDIR /home/${USERNAME}
+USER ${USERNAME}
+
+COPY requirements.txt requirements.txt
+
+RUN python3 -m venv ./.venv && \
+    . ./.venv/bin/activate && \
+    pip install --upgrade pip && \
+    pip install pre-commit && \
+    pip install -r requirements.txt && \
+    echo 'source /home/pyaedt/.venv/bin/activate' >> ~/.bashrc && \
+    rm requirements.txt
+
+WORKDIR /home/${USERNAME}/pyaedt-mcp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "PyAEDT-MCP-DevContainer",
+  "dockerComposeFile": [
+    "docker-compose.yml"
+  ],
+  "service": "pyaedtdev",
+  "workspaceFolder": "/home/pyaedt/pyaedt-mcp",
+  "postCreateCommand": "/bin/bash ./.devcontainer/start.sh",
+  "remoteUser": "root",
+  "updateRemoteUserUID": true,
+  "customizations": {
+    "vscode": {
+      "openFiles": [
+        ".devcontainer/welcome.rst"
+      ],
+      "extensions": [
+        "ms-python.python"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/home/pyaedt/pyaedt-mcp/.venv_pyaedt/bin/python",
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.testing.pytestArgs": [
+          "tests"
+        ],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.3"
+name: "PyAEDT-MCP-Development"
+
+services:
+  pyaedtdev:
+    restart: always
+    shm_size: "2gb"
+    container_name: "PyAEDT-Development"
+    mem_reservation: 8g
+    build:
+      dockerfile: Dockerfile
+      context: .
+    volumes:
+      - ../:/home/pyaedt/pyaedt-mcp:cached
+    entrypoint: /bin/bash -c "while sleep 10000; do :; done"

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,11 @@
+pyaedt[all]>=0.10.0
+pytest==9.0.1
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+pytest-mock==3.15.1
+black==25.11.0
+fastmcp==3.2.0
+isort==7.0.0
+mypy==1.18.2
+pre_commit==4.5.0
+flake8==7.3.0

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "Starting local development container"
+
+echo "Activating virtual environment..."
+ln -s /home/pyaedt/.venv /home/pyaedt/pyaedt-mcp/.venv_pyaedt && echo "Linking venv original dir"
+# shellcheck disable=SC1091
+source ./.venv_pyaedt/bin/activate
+
+echo "Installing PyAEDT-MCP package and dependencies for development"
+git fetch && git pull
+pip install -e '.[tests]'
+
+echo "Setting pre-commit..."
+pre-commit install --install-hooks
+
+echo "Done! Enjoy PyAEDT!"

--- a/.devcontainer/welcome.rst
+++ b/.devcontainer/welcome.rst
@@ -1,0 +1,4 @@
+Welcome to VSCode DevContainer!
+===============================
+
+This DevContainer has been specifically set for developing and/or documenting PyAEDT-MCP.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyAEDT MCP Server
 
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache%202.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 `ansys-aedt-mcp` is an MCP server for Ansys Electronics Desktop (AEDT). It gives an AI client a small set of reliable AEDT tools, plus a persistent PyAEDT-backed Python session for the steps that do not fit a dedicated tool.
 
@@ -172,7 +172,7 @@ If a tool is intentionally available before connection, leave that tag off and m
 
 ## License
 
-MIT License. See [LICENSE](LICENSE).
+Apache 2.0 License. See [LICENSE](LICENSE).
 
 ## Related projects
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 coverage:
-  range: 60..100
+  range: 80..100
   round: down
   precision: 2
   status:
     project:
       default:
-        target: 60%
+        target: 80%
     patch: off
 
 codecov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,14 @@ lint.select = [
   "F",   # pyflakes
   "I",   # isort
   "N",   # pep8-naming
+  "PTH", # flake8-use-pathlib
+  "TD",  # flake8-todos
 ]
 lint.ignore = [
   "D100", # Missing docstring in public module
   "D104", # Missing docstring in public package
   "D401", # First line of docstring should be in imperative mood
+  "TD002", # Missing author in TODO comments
 ]
 lint.per-file-ignores."!src/**.py" = [ "D" ]
 lint.per-file-ignores."__init__.py" = [ "F401" ]
@@ -134,18 +137,19 @@ warn_return_any = true
 warn_unused_configs = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=ansys.aedt.mcp --cov-report=term-missing --tb=short -q"
+addopts = "--cov=ansys.aedt.mcp --cov-report=term-missing --cov-report=html --cov-report=xml --tb=short -q"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 markers = [
   "integration: marks tests as integration tests (require running AEDT instance)",
   "unit: marks tests as unit tests (do not require running AEDT instance)",
+  "slow: Tests that take a long time to run",
 ]
 testpaths = ["tests"]
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", "venv"]
-skips = ["B101", "B102", "B110", "B404", "B603", "B606", "B607"]  # assert, exec, try/except/pass, subprocess
+skips = ["B101"]  # Skip assert_used in tests
 
 [tool.uv]
 index-strategy = "unsafe-best-match"

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -129,11 +129,11 @@ def _resolve_pyaedt_log_file() -> str | None:
         if raw_logger is not None:
             for handler in getattr(raw_logger, "handlers", []):
                 handler_path = getattr(handler, "baseFilename", None)
-                if handler_path and os.path.isfile(handler_path):
+                if handler_path and Path(handler_path).is_file():
                     return str(Path(handler_path).expanduser().resolve())
 
         logger_filename = getattr(pyaedt_logger, "filename", None)
-        if logger_filename and os.path.isfile(logger_filename):
+        if logger_filename and Path(logger_filename).is_file():
             return str(Path(logger_filename).expanduser().resolve())
     except Exception:
         logger.debug("Failed to resolve PyAEDT log file from pyaedt_logger.", exc_info=True)
@@ -300,7 +300,7 @@ def get_pyaedt_logs(
                 "Run a PyAEDT operation first to initialize the logger."
             )
 
-        with open(log_file, "r", encoding="utf-8", errors="replace") as file_handle:
+        with Path(log_file).open("r", encoding="utf-8", errors="replace") as file_handle:
             all_lines = file_handle.readlines()
 
         filtered_lines = all_lines
@@ -685,7 +685,7 @@ def run_python_script(ctx: Context, script_path: str) -> str:
         )
 
     try:
-        if not os.path.exists(script_path):
+        if not Path(script_path).exists():
             return f"Script file not found: {script_path}"
 
         logger.info(f"Executing script: {script_path}")
@@ -886,7 +886,7 @@ def open_project(ctx: Context, project_path: str, design_name: str | None = None
         )
 
     try:
-        if not os.path.exists(project_path):
+        if not Path(project_path).exists():
             return f"Project file not found: {project_path}"
 
         logger.info(f"Opening project: {project_path}")
@@ -1339,7 +1339,7 @@ def screenshot(
         if not image_path.exists():
             raise RuntimeError(f"Screenshot file not created: {output_path}")
 
-        with open(image_path, "rb") as f:
+        with image_path.open("rb") as f:
             image_data = f.read()
         base64_data = base64.b64encode(image_data).decode("utf-8")
         mime_type = "image/jpeg"
@@ -1426,7 +1426,7 @@ def export_config(
         else:
             fd, config_target = tempfile.mkstemp(suffix=".json")
             os.close(fd)
-            os.remove(config_target)
+            Path(config_target).unlink()
             temp_config_file = config_target
 
         config_file = app_instance.configurations.export_config(
@@ -1435,7 +1435,7 @@ def export_config(
         if not config_file:
             raise RuntimeError("Failed to export configuration.")
 
-        with open(config_file, "r", encoding="utf-8") as file_handle:
+        with Path(config_file).open("r", encoding="utf-8") as file_handle:
             config_content = json.load(file_handle)
 
         data: dict[str, Any] = {
@@ -1453,8 +1453,8 @@ def export_config(
         logger.error(error_msg)
         return error_msg
     finally:
-        if temp_config_file and os.path.exists(temp_config_file):
-            os.remove(temp_config_file)
+        if temp_config_file and Path(temp_config_file).exists():
+            Path(temp_config_file).unlink()
 
 
 @app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -5,7 +5,7 @@
 
 import runpy
 import sys
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Additional unit tests for helper and startup modules."""
+
+import runpy
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansys.aedt.mcp import helpers
+
+
+def test_probe_grpc_endpoint_unreachable(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise OSError("connection failed")
+
+    monkeypatch.setattr(helpers.socket, "create_connection", _raise)
+
+    result = helpers._probe_grpc_endpoint("127.0.0.1", 50051)
+
+    assert result["reachable"] is False
+    assert "connection failed" in result["error"]
+
+
+def test_get_aedt_info_error_paths():
+    class _Desktop:
+        @property
+        def aedt_version_id(self):
+            raise RuntimeError("broken connection")
+
+        @property
+        def project_list(self):
+            raise RuntimeError("no projects")
+
+        @property
+        def installed_versions(self):
+            raise RuntimeError("no versions")
+
+        def active_project(self):
+            raise RuntimeError("active project error")
+
+        def active_design(self):
+            raise RuntimeError("active design error")
+
+    info = helpers.get_aedt_info(_Desktop())
+
+    assert "error" in info["connection"]
+    assert "projects_error" in info
+    assert info["active_project"] is None
+    assert info["active_design"] is None
+    assert "installed_versions_error" in info
+
+
+def test_get_design_info_error_paths():
+    class _VariableManager:
+        @property
+        def design_variables(self):
+            raise RuntimeError("bad vars")
+
+    class _App:
+        @property
+        def design_name(self):
+            raise RuntimeError("bad design")
+
+        @property
+        def setups(self):
+            raise RuntimeError("bad setups")
+
+        @property
+        def boundaries(self):
+            raise RuntimeError("bad boundaries")
+
+        variable_manager = _VariableManager()
+
+    info = helpers.get_design_info(_App())
+
+    assert "error" in info
+    assert info["setups"] == []
+    assert info["boundaries"] == []
+    assert info["design_variables"] == []
+
+
+def test_parse_aedt_version_edge_cases():
+    assert helpers.parse_aedt_version("abcd") == "abcd"
+    assert helpers.parse_aedt_version("2026.a") == "2026a"
+    assert helpers.parse_aedt_version("  261  ") == "261"
+
+
+def test_get_design_type_map_contains_expected_keys():
+    design_map = helpers.get_design_type_map()
+    assert "HFSS" in design_map
+    assert "HFSS 3D Layout Design" in design_map
+
+
+def test_resolve_design_app_uses_active_project_and_design(monkeypatch):
+    class _Named:
+        def __init__(self, name):
+            self._name = name
+
+        def GetName(self):
+            return self._name
+
+    class _Desktop:
+        def active_project(self):
+            return _Named("ProjA")
+
+        def active_design(self):
+            return _Named("DesignA")
+
+        def design_type(self, design_name=None):
+            assert design_name == "DesignA"
+            return "HFSS"
+
+    class _App:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.project_name = kwargs.get("project")
+            self.design_name = kwargs.get("design")
+
+    monkeypatch.setattr(helpers, "get_design_type_map", lambda: {"HFSS": _App})
+
+    app, project_name, design_name = helpers.resolve_design_app(_Desktop())
+
+    assert isinstance(app, _App)
+    assert project_name == "ProjA"
+    assert design_name == "DesignA"
+    assert app.kwargs["new_desktop"] is False
+
+
+def test_resolve_design_app_unsupported_type(monkeypatch):
+    desktop = MagicMock()
+    desktop.active_project.return_value = None
+    desktop.active_design.return_value = None
+    desktop.design_type.return_value = "UnsupportedType"
+
+    monkeypatch.setattr(helpers, "get_design_type_map", lambda: {"HFSS": object})
+
+    with pytest.raises(RuntimeError, match="Unsupported design type"):
+        helpers.resolve_design_app(desktop)
+
+
+def test_startup_code_save_plot_paths(monkeypatch):
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", False)
+    assert "matplotlib is not installed" in startup_code.save_matplotlib_plot()
+
+    plotter = MagicMock()
+    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", False)
+    assert startup_code.save_pyvista_plot(plotter) == "PyVista is not available"
+
+
+def test_module_entrypoint_invokes_launcher(monkeypatch):
+    fake_server = ModuleType("ansys.aedt.mcp.server")
+    launcher = MagicMock()
+    fake_server.launcher = launcher
+
+    monkeypatch.setitem(sys.modules, "ansys.aedt.mcp.server", fake_server)
+    runpy.run_module("ansys.aedt.mcp.__main__", run_name="__main__")
+
+    launcher.assert_called_once()

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -3,6 +3,7 @@
 
 """Additional unit tests for helper and startup modules."""
 
+import builtins
 from pathlib import Path
 import runpy
 import sys
@@ -25,6 +26,35 @@ def test_open_file_in_default_viewer_paths(monkeypatch):
     monkeypatch.setattr(tools, "_is_docker", lambda: False)
     monkeypatch.setattr(tools.os, "startfile", lambda path: None, raising=False)
     assert tools._open_file_in_default_viewer(Path("C:/tmp/file.txt")) is None
+
+
+def test_open_file_in_default_viewer_platform_paths(monkeypatch):
+    from ansys.aedt.mcp import tools
+
+    monkeypatch.setattr(tools, "_is_docker", lambda: False)
+    monkeypatch.delattr(tools.os, "startfile", raising=False)
+
+    monkeypatch.setattr(tools.sys, "platform", "darwin")
+    monkeypatch.setattr(tools.shutil, "which", lambda name: None)
+    msg = tools._open_file_in_default_viewer(Path("/tmp/file.txt"))
+    assert "open" in msg
+
+    monkeypatch.setattr(tools.sys, "platform", "linux")
+    monkeypatch.setattr(tools.shutil, "which", lambda name: None)
+    msg = tools._open_file_in_default_viewer(Path("/tmp/file.txt"))
+    assert "xdg-open" in msg
+
+
+def test_open_file_in_default_viewer_exception(monkeypatch):
+    from ansys.aedt.mcp import tools
+
+    monkeypatch.setattr(tools, "_is_docker", lambda: False)
+    monkeypatch.setattr(
+        tools.os, "startfile", lambda path: (_ for _ in ()).throw(OSError("boom")), raising=False
+    )
+
+    msg = tools._open_file_in_default_viewer(Path("C:/tmp/file.txt"))
+    assert "Viewer launch failed" in msg
 
 
 def test_configure_pyaedt_runtime_settings(monkeypatch):
@@ -62,6 +92,49 @@ def test_resolve_pyaedt_log_file_from_logger_handler(monkeypatch, tmp_path):
     result = tools._resolve_pyaedt_log_file()
 
     assert result == str(log_file.resolve())
+
+
+def test_resolve_pyaedt_log_file_from_logger_filename(monkeypatch, tmp_path):
+    from ansys.aedt.mcp import tools
+
+    log_file = tmp_path / "from-filename.log"
+    log_file.write_text("ok", encoding="utf-8")
+
+    fake_logger = MagicMock()
+    fake_logger.logger = None
+    fake_logger.filename = str(log_file)
+    fake_logger_module = ModuleType("ansys.aedt.core.aedt_logger")
+    fake_logger_module.pyaedt_logger = fake_logger
+    monkeypatch.setitem(sys.modules, "ansys.aedt.core.aedt_logger", fake_logger_module)
+
+    result = tools._resolve_pyaedt_log_file()
+
+    assert result == str(log_file.resolve())
+
+
+def test_resolve_pyaedt_log_file_from_settings_dir(monkeypatch, tmp_path):
+    from ansys.aedt.mcp import tools
+
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    older = logs_dir / "pyaedt_old.log"
+    newer = logs_dir / "pyaedt_new.log"
+    older.write_text("old", encoding="utf-8")
+    newer.write_text("new", encoding="utf-8")
+
+    fake_logger_module = ModuleType("ansys.aedt.core.aedt_logger")
+    # Force logger branch to fall through.
+    fake_logger_module.pyaedt_logger = object()
+    monkeypatch.setitem(sys.modules, "ansys.aedt.core.aedt_logger", fake_logger_module)
+
+    fake_settings = ModuleType("ansys.aedt.core")
+    fake_settings.settings = MagicMock()
+    fake_settings.settings.logger_file_path = str(logs_dir)
+    monkeypatch.setitem(sys.modules, "ansys.aedt.core", fake_settings)
+
+    result = tools._resolve_pyaedt_log_file()
+
+    assert result.endswith("pyaedt_new.log") or result.endswith("pyaedt_old.log")
 
 
 def test_get_aedt_app_class_known_and_unknown():
@@ -277,6 +350,31 @@ def test_startup_code_get_aedt_version_paths(monkeypatch):
 
     monkeypatch.setattr(aedt_module, "__version__", "1.2.3")
     assert startup_code.get_aedt_version() == "1.2.3"
+
+
+def test_startup_code_get_aedt_version_import_error(monkeypatch):
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    original_import = builtins.__import__
+
+    def _import_raises(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ansys.aedt.core":
+            raise ImportError("missing")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import_raises)
+
+    assert startup_code.get_aedt_version() == "PyAEDT not available"
+
+
+def test_startup_code_list_aedt_applications():
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    apps = startup_code.list_aedt_applications()
+
+    assert isinstance(apps, list)
+    assert len(apps) >= 10
+    assert any(item.startswith("Hfss") for item in apps)
 
 
 def test_module_entrypoint_invokes_launcher(monkeypatch):

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -3,6 +3,7 @@
 
 """Additional unit tests for helper and startup modules."""
 
+from pathlib import Path
 import runpy
 import sys
 from types import ModuleType
@@ -11,6 +12,64 @@ from unittest.mock import MagicMock
 import pytest
 
 from ansys.aedt.mcp import helpers
+
+
+def test_open_file_in_default_viewer_paths(monkeypatch):
+    from ansys.aedt.mcp import tools
+
+    monkeypatch.setattr(tools, "_is_docker", lambda: True)
+    assert tools._open_file_in_default_viewer(Path("C:/tmp/file.txt")) == (
+        "Viewer launch skipped inside Docker."
+    )
+
+    monkeypatch.setattr(tools, "_is_docker", lambda: False)
+    monkeypatch.setattr(tools.os, "startfile", lambda path: None, raising=False)
+    assert tools._open_file_in_default_viewer(Path("C:/tmp/file.txt")) is None
+
+
+def test_configure_pyaedt_runtime_settings(monkeypatch):
+    from ansys.aedt.mcp import tools
+
+    fake_settings = MagicMock()
+    fake_module = ModuleType("ansys.aedt.core")
+    fake_module.settings = fake_settings
+
+    monkeypatch.setitem(sys.modules, "ansys.aedt.core", fake_module)
+    tools._configure_pyaedt_runtime_settings(enable_grpc=True)
+
+    assert fake_settings.use_grpc_api is True
+    assert fake_settings.release_on_exception is False
+
+
+def test_resolve_pyaedt_log_file_from_logger_handler(monkeypatch, tmp_path):
+    from ansys.aedt.mcp import tools
+
+    log_file = tmp_path / "pyaedt.log"
+    log_file.write_text("hello", encoding="utf-8")
+
+    handler = MagicMock()
+    handler.baseFilename = str(log_file)
+    raw_logger = MagicMock()
+    raw_logger.handlers = [handler]
+    fake_logger = MagicMock()
+    fake_logger.logger = raw_logger
+
+    fake_logger_module = ModuleType("ansys.aedt.core.aedt_logger")
+    fake_logger_module.pyaedt_logger = fake_logger
+
+    monkeypatch.setitem(sys.modules, "ansys.aedt.core.aedt_logger", fake_logger_module)
+
+    result = tools._resolve_pyaedt_log_file()
+
+    assert result == str(log_file.resolve())
+
+
+def test_get_aedt_app_class_known_and_unknown():
+    from ansys.aedt.mcp import tools
+
+    assert tools._get_aedt_app_class("Hfss") is not None
+    assert tools._get_aedt_app_class("Mechanical") is not None
+    assert tools._get_aedt_app_class("Unknown") is None
 
 
 def test_probe_grpc_endpoint_unreachable(monkeypatch):
@@ -149,6 +208,75 @@ def test_startup_code_save_plot_paths(monkeypatch):
     plotter = MagicMock()
     monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", False)
     assert startup_code.save_pyvista_plot(plotter) == "PyVista is not available"
+
+
+def test_startup_code_matplotlib_file_output(monkeypatch, tmp_path):
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    output_path = tmp_path / "plot.png"
+    fake_plt = MagicMock()
+    fake_plt.savefig.return_value = None
+    fake_plt.close.return_value = None
+
+    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", True)
+    monkeypatch.setattr(startup_code, "plt", fake_plt)
+
+    result = startup_code.save_matplotlib_plot(
+        filename=str(output_path), return_base64=False, dpi=175
+    )
+
+    assert result == f"Plot saved to {output_path}"
+    fake_plt.savefig.assert_called_once_with(str(output_path), dpi=175, bbox_inches="tight")
+    fake_plt.close.assert_called_once()
+
+
+def test_startup_code_matplotlib_base64_output(monkeypatch):
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    fake_buffer = MagicMock()
+    fake_buffer.read.return_value = b"plot-bytes"
+    fake_plt = MagicMock()
+    fake_plt.savefig.return_value = None
+    fake_plt.close.return_value = None
+
+    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", True)
+    monkeypatch.setattr(startup_code, "plt", fake_plt)
+    monkeypatch.setattr(startup_code, "BytesIO", lambda: fake_buffer)
+    monkeypatch.setattr(startup_code.base64, "b64encode", lambda data: b"encoded")
+
+    result = startup_code.save_matplotlib_plot(return_base64=True, dpi=90)
+
+    assert result == "data:image/png;base64,encoded"
+    fake_plt.savefig.assert_called_once_with(fake_buffer, format="PNG", dpi=90, bbox_inches="tight")
+    fake_plt.close.assert_called_once()
+
+
+def test_startup_code_pyvista_file_output(monkeypatch):
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    fake_plotter = MagicMock()
+    fake_plotter.screenshot.return_value = None
+    fake_plotter.close.return_value = None
+
+    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", True)
+    monkeypatch.setattr(startup_code, "PIL_AVAILABLE", False)
+
+    result = startup_code.save_pyvista_plot(
+        fake_plotter, filename="C:/tmp/plot.png", return_base64=True
+    )
+
+    assert result == "Plot saved to C:/tmp/plot.png"
+    fake_plotter.screenshot.assert_called_once_with("C:/tmp/plot.png", transparent_background=False)
+    fake_plotter.close.assert_called_once()
+
+
+def test_startup_code_get_aedt_version_paths(monkeypatch):
+    import ansys.aedt.core as aedt_module
+
+    from ansys.aedt.mcp.aedt_helper import startup_code
+
+    monkeypatch.setattr(aedt_module, "__version__", "1.2.3")
+    assert startup_code.get_aedt_version() == "1.2.3"
 
 
 def test_module_entrypoint_invokes_launcher(monkeypatch):

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -99,9 +99,7 @@ def test_resolve_design_app_uses_active_project_and_design(monkeypatch):
     class _Named:
         def __init__(self, name):
             self._name = name
-
-        def GetName(self):
-            return self._name
+            self.GetName = lambda: self._name
 
     class _Desktop:
         def active_project(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -21,6 +21,7 @@ These tests mock the AEDT Desktop instance and verify tool behavior.
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -392,6 +393,30 @@ class TestSaveProject:
         result = save_project(mock_context)
         assert "saved successfully" in result or "No project" in result
 
+    def test_save_project_save_as(self, mock_context):
+        """Test save-as branch for explicit output path."""
+        from ansys.aedt.mcp.tools import save_project
+
+        result = save_project(mock_context, save_as="C:/tmp/new_project.aedt")
+
+        mock_context.request_context.lifespan_context.desktop.save_project.assert_called_with(
+            project_file="C:/tmp/new_project.aedt"
+        )
+        assert "Project saved to" in result
+
+    def test_save_project_exception(self, mock_context):
+        """Test save project exception handling."""
+        from ansys.aedt.mcp.tools import save_project
+
+        mock_context.request_context.lifespan_context.desktop.save_project.side_effect = (
+            RuntimeError("save failed")
+        )
+
+        result = save_project(mock_context)
+
+        assert "Error saving project" in result
+        assert "save failed" in result
+
 
 @pytest.mark.unit
 class TestClearAEDT:
@@ -410,6 +435,19 @@ class TestClearAEDT:
 
         result = clear_aedt(mock_context)
         assert "cleared" in result or "AEDT" in result
+
+    def test_clear_error(self, mock_context):
+        """Test clear operation exception handling."""
+        from ansys.aedt.mcp.tools import clear_aedt
+
+        mock_context.request_context.lifespan_context.desktop.clear_messages.side_effect = (
+            RuntimeError("clear failed")
+        )
+
+        result = clear_aedt(mock_context)
+
+        assert "Error clearing AEDT" in result
+        assert "clear failed" in result
 
 
 @pytest.mark.unit
@@ -444,6 +482,42 @@ class TestCreateDesign:
 
         result = create_design(mock_context, "InvalidApp", "TestDesign")  # type: ignore
         assert "Unsupported" in result or "Error" in result
+
+    def test_create_design_with_optional_kwargs(self, mock_context):
+        """Test create_design forwards optional project and solution arguments."""
+        from ansys.aedt.mcp.tools import create_design
+
+        with patch("ansys.aedt.core.Hfss") as mock_hfss:
+            mock_instance = MagicMock()
+            mock_instance.design_name = "OptDesign"
+            mock_instance.project_name = "OptProject"
+            mock_instance.solution_type = "DrivenModal"
+            mock_hfss.return_value = mock_instance
+
+            result = create_design(
+                mock_context,
+                "Hfss",
+                design_name="OptDesign",
+                project_name="OptProject",
+                solution_type="DrivenModal",
+            )
+
+        mock_hfss.assert_called_once_with(
+            design="OptDesign",
+            project="OptProject",
+            solution_type="DrivenModal",
+        )
+        assert "Successfully created Hfss design" in result
+
+    def test_create_design_exception(self, mock_context):
+        """Test create_design exception handling."""
+        from ansys.aedt.mcp.tools import create_design
+
+        with patch("ansys.aedt.core.Hfss", side_effect=RuntimeError("create failed")):
+            result = create_design(mock_context, "Hfss", "BrokenDesign")
+
+        assert "Error creating design" in result
+        assert "create failed" in result
 
 
 @pytest.mark.unit
@@ -638,6 +712,41 @@ class TestAnalyzeDesign:
 
         mock_context.request_context.lifespan_context.desktop.analyze_all.assert_not_called()
         assert "setup_name cannot be used" in result
+
+    def test_analyze_design_analyze_all_failure(self, mock_context):
+        """Test desktop analyze_all failure response."""
+        from ansys.aedt.mcp.tools import analyze_design
+
+        mock_context.request_context.lifespan_context.desktop.analyze_all.return_value = False
+
+        result = analyze_design(mock_context, analyze_all_designs=True)
+
+        assert "Analysis failed during desktop-wide analyze_all invocation" in result
+
+    def test_analyze_design_app_failure(self, mock_context):
+        """Test design-level analyze false result message."""
+        from ansys.aedt.mcp.tools import analyze_design
+
+        mock_app = MagicMock()
+        mock_app.project_name = "Project1"
+        mock_app.design_name = "Design1"
+        mock_app.analyze.return_value = False
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = analyze_design(mock_context, setup_name="Setup1")
+
+        assert "Analysis failed." in result
+        assert "Setup: Setup1" in result
+
+    def test_analyze_design_exception(self, mock_context):
+        """Test analyze_design exception handling."""
+        from ansys.aedt.mcp.tools import analyze_design
+
+        with patch("ansys.aedt.core.get_pyaedt_app", side_effect=RuntimeError("analyze boom")):
+            result = analyze_design(mock_context)
+
+        assert "Error during analysis" in result
+        assert "analyze boom" in result
 
 
 @pytest.mark.unit
@@ -954,6 +1063,205 @@ class TestExportResults:
 
         result = export_results(mock_context, output_path="/tmp/out.csv", export_type="convergence")
         assert isinstance(result, str)
+
+
+@pytest.mark.unit
+class TestExportResultsExtended:
+    """Additional branch tests for export_results tool."""
+
+    @pytest.mark.parametrize(
+        ("export_type", "method_name", "success_text"),
+        [
+            ("touchstone", "export_touchstone", "Touchstone exported"),
+            ("profile", "export_profile", "Profile exported"),
+            ("convergence", "export_convergence", "Convergence data exported"),
+            ("mesh", "export_mesh_stats", "Mesh stats exported"),
+        ],
+    )
+    def test_export_result_type_success(
+        self,
+        mock_context,
+        export_type,
+        method_name,
+        success_text,
+    ):
+        """Test successful export branches for all supported export types."""
+        from ansys.aedt.mcp.tools import export_results
+
+        mock_app = MagicMock()
+        getattr(mock_app, method_name).return_value = "OK"
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = export_results(
+                mock_context,
+                output_path="/tmp/out.file",
+                export_type=export_type,
+                setup_name="Setup1",
+            )
+
+        assert success_text in result
+
+    @pytest.mark.parametrize(
+        ("export_type", "missing_method"),
+        [
+            ("touchstone", "export_touchstone"),
+            ("profile", "export_profile"),
+            ("convergence", "export_convergence"),
+            ("mesh", "export_mesh_stats"),
+        ],
+    )
+    def test_export_result_type_unavailable(self, mock_context, export_type, missing_method):
+        """Test unsupported export methods on resolved app objects."""
+        from ansys.aedt.mcp.tools import export_results
+
+        app_without_method = SimpleNamespace()
+        # Ensure only the targeted method is absent.
+        for method in [
+            "export_touchstone",
+            "export_profile",
+            "export_convergence",
+            "export_mesh_stats",
+        ]:
+            if method != missing_method:
+                setattr(app_without_method, method, MagicMock(return_value="OK"))
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=app_without_method):
+            result = export_results(
+                mock_context, output_path="/tmp/out.file", export_type=export_type
+            )
+
+        assert "not available" in result
+
+    def test_export_unknown_type(self, mock_context):
+        """Test unknown export type validation message."""
+        from ansys.aedt.mcp.tools import export_results
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=MagicMock()):
+            result = export_results(
+                mock_context, output_path="/tmp/out.file", export_type="unknown"
+            )
+
+        assert "Unknown export type" in result
+        assert "Supported: touchstone, profile, convergence, mesh" in result
+
+    def test_export_get_pyaedt_app_exception(self, mock_context):
+        """Test app resolution failure path in export_results."""
+        from ansys.aedt.mcp.tools import export_results
+
+        with patch("ansys.aedt.core.get_pyaedt_app", side_effect=RuntimeError("no design")):
+            result = export_results(mock_context, output_path="/tmp/out.file")
+
+        assert "requires an active application" in result
+
+    def test_export_method_raises_exception(self, mock_context):
+        """Test outer exception handling when export method raises."""
+        from ansys.aedt.mcp.tools import export_results
+
+        mock_app = MagicMock()
+        mock_app.export_touchstone.side_effect = RuntimeError("export boom")
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = export_results(
+                mock_context, output_path="/tmp/out.file", export_type="touchstone"
+            )
+
+        assert "Error exporting results" in result
+        assert "export boom" in result
+
+
+@pytest.mark.unit
+class TestToolErrorBranches:
+    """Additional branch/error tests for top-level tools."""
+
+    def test_check_aedt_status_exception(self, mock_context):
+        """Test status check when backend info retrieval fails."""
+        from ansys.aedt.mcp.tools import check_aedt_status
+
+        with patch("ansys.aedt.mcp.tools.get_aedt_info", side_effect=RuntimeError("status boom")):
+            result = check_aedt_status(mock_context)
+
+        assert "Error checking AEDT status" in result
+        assert "status boom" in result
+
+    def test_get_pyaedt_logs_max_chars_validation(self, mock_context_no_desktop):
+        """Test validation for max_chars parameter."""
+        from ansys.aedt.mcp.tools import get_pyaedt_logs
+
+        result = get_pyaedt_logs(mock_context_no_desktop, max_chars=0)
+        assert "max_chars must be greater than 0" in result
+
+    def test_get_pyaedt_logs_truncation(self, mock_context_no_desktop, tmp_path):
+        """Test large log payload truncation path."""
+        from ansys.aedt.mcp.tools import get_pyaedt_logs
+
+        log_file = tmp_path / "pyaedt_long.log"
+        log_file.write_text("line1\nline2\nline3\nline4\n", encoding="utf-8")
+
+        with patch("ansys.aedt.mcp.tools._resolve_pyaedt_log_file", return_value=str(log_file)):
+            result = get_pyaedt_logs(
+                mock_context_no_desktop,
+                tail_lines=100,
+                max_chars=8,
+            )
+
+        data = json.loads(result)
+        assert data["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_launch_application_without_desktop_handle(self, mock_context_no_desktop):
+        """Test application launch failure when desktop handle cannot be resolved."""
+        from ansys.aedt.mcp.tools import launch_aedt
+
+        mock_versions = MagicMock()
+        mock_versions.current_version = "2026.1"
+        mock_versions.latest_version = "2026.1"
+
+        app_instance = MagicMock()
+        app_instance.desktop_class = None
+
+        with (
+            patch("ansys.aedt.mcp.tools._is_docker", return_value=False),
+            patch("ansys.aedt.mcp.tools.aedt_versions", mock_versions),
+            patch("ansys.aedt.core.Hfss", return_value=app_instance),
+            patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
+        ):
+            result = await launch_aedt(mock_context_no_desktop, application="Hfss")
+
+        assert "Failed to launch AEDT" in result
+        assert "Unable to resolve desktop handle" in result
+
+    @pytest.mark.asyncio
+    async def test_connect_tip_with_project_name(self, mock_context_no_desktop):
+        """Test connect tip text when project_name is provided without design_name."""
+        from ansys.aedt.mcp.tools import connect_to_aedt
+
+        fake_desktop = MagicMock()
+        fake_desktop.aedt_version_id = "2026.1"
+        fake_desktop.is_grpc_api = True
+
+        with (
+            patch("ansys.aedt.mcp.tools._is_docker", return_value=False),
+            patch("ansys.aedt.core.Desktop", return_value=fake_desktop),
+            patch("ansys.aedt.mcp.tools._configure_pyaedt_runtime_settings"),
+        ):
+            result = await connect_to_aedt(mock_context_no_desktop, project_name="P1")
+
+        assert "Tip: provide design_name" in result
+        assert "and project_name" not in result
+
+    @pytest.mark.asyncio
+    async def test_disconnect_exception_still_clears_desktop(self, mock_context):
+        """Test disconnect exception branch clears context desktop."""
+        from ansys.aedt.mcp.tools import disconnect_from_aedt
+
+        mock_context.request_context.lifespan_context.desktop.release_desktop.side_effect = (
+            RuntimeError("disconnect boom")
+        )
+
+        result = await disconnect_from_aedt(mock_context)
+
+        assert "Error during AEDT disconnect" in result
+        assert mock_context.request_context.lifespan_context.desktop is None
 
 
 @pytest.mark.unit

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -360,7 +360,7 @@ class TestOpenProject:
         """Test open project with non-existent file."""
         from ansys.aedt.mcp.tools import open_project
 
-        with patch("ansys.aedt.mcp.tools.os.path.exists", return_value=False):
+        with patch("ansys.aedt.mcp.tools.Path.exists", return_value=False):
             result = open_project(mock_context, project_path="nonexistent.aedt")
             assert "not found" in result
 
@@ -368,7 +368,7 @@ class TestOpenProject:
         """Test successful project open."""
         from ansys.aedt.mcp.tools import open_project
 
-        with patch("ansys.aedt.mcp.tools.os.path.exists", return_value=True):
+        with patch("ansys.aedt.mcp.tools.Path.exists", return_value=True):
             result = open_project(mock_context, project_path="test.aedt")
             assert "Successfully opened" in result
 
@@ -794,7 +794,7 @@ class TestExportConfig:
             patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app),
             patch("tempfile.mkstemp", return_value=(0, str(config_path))),
             patch("os.close"),
-            patch("os.remove"),
+            patch("ansys.aedt.mcp.tools.Path.unlink"),
         ):
             result = export_config(mock_context)
 
@@ -1007,7 +1007,7 @@ class TestRunPythonScript:
         """Test run script with non-existent file."""
         from ansys.aedt.mcp.tools import run_python_script
 
-        with patch("ansys.aedt.mcp.tools.os.path.exists", return_value=False):
+        with patch("ansys.aedt.mcp.tools.Path.exists", return_value=False):
             result = run_python_script(mock_context, script_path="/missing/script.py")
 
         assert "Script file not found" in result
@@ -1018,7 +1018,7 @@ class TestRunPythonScript:
 
         mock_context.request_context.lifespan_context.desktop.odesktop.RunScript.return_value = "OK"
 
-        with patch("ansys.aedt.mcp.tools.os.path.exists", return_value=True):
+        with patch("ansys.aedt.mcp.tools.Path.exists", return_value=True):
             result = run_python_script(mock_context, script_path="test.py")
 
         assert "Script executed successfully" in result
@@ -1032,7 +1032,7 @@ class TestRunPythonScript:
             RuntimeError("Script crashed")
         )
 
-        with patch("ansys.aedt.mcp.tools.os.path.exists", return_value=True):
+        with patch("ansys.aedt.mcp.tools.Path.exists", return_value=True):
             result = run_python_script(mock_context, script_path="test.py")
 
         assert "Error executing script" in result


### PR DESCRIPTION
## Summary
- Raised test coverage from ~81% to 92%.
- Closed utility/tool-level gaps and kept all tests green.
- Reduced Bandit global skips and aligned standards with pymapdl-mcp baseline.

## What was added
- Expanded branch tests in tests/test_tools.py and tests/test_helpers_additional.py.
- Export, status/logging, analyze, save/create, and disconnect error-path coverage.
- Ruff parity update: enabled PTH and TD rules.
- Pathlib refactor in runtime code to satisfy PTH checks.
- Bandit global skips reduced to B101 only (from B101/B102/B110/B404/B603/B606/B607).
- New .devcontainer setup added for local/devcontainer parity.
- Codecov policy tightened from 60% to 80% target.
- README license badge/text corrected to Apache-2.0.

## Validation
- pre-commit --all-files: pass (ruff, mypy, bandit, formatting).
- Full suite: 204 passed.
- Coverage: 92% overall.