### PR TITLE
chore: dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           pytest-markers: '-m "not integration"'
+          group-dependencies-name: test
 
   build-docs:
     name: "Build documentation"
@@ -158,6 +159,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           dependencies: 'zip libgl1 libglx-mesa0 xvfb'
           sphinxopts: '-W --keep-going'
+          group-dependencies-name: doc
 
   package:
     name: "Package library"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ doc = [
   "sphinx-design>=0.5.0",
   "sphinx-notfound-page==1.1.0",
   "sphinx==8.2.3",
+  "sphinxcontrib-video==0.4.2",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["flit_core >=3.2,<4"]
 
 [project]
 authors = [{name = "Synopsys, Inc. and ANSYS, Inc.", email = "pyansys-core@synopsys.com"}]
-maintainers = [{ name = "Synopsys, Inc. and ANSYS, Inc.", email = "pyansys-core@synopsys.com" }]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -38,6 +37,7 @@ keywords = [
   "thermal-analysis",
 ]
 license = {file = "LICENSE"}
+maintainers = [{name = "Synopsys, Inc. and ANSYS, Inc.", email = "pyansys-core@synopsys.com"}]
 name = "ansys-aedt-mcp"
 readme = "README.md"
 requires-python = ">=3.10,<4"
@@ -51,8 +51,17 @@ dependencies = [
   "tabulate>=0.9.0",
 ]
 
-[project.optional-dependencies]
-tests = [
+[dependency-groups]
+dev = [
+  "pre-commit>=4.0",
+  "ruff>=0.11.0",
+  "mypy>=1.8.0",
+  "bandit[toml]>=1.8.0",
+  { include-group = "doc" },
+  { include-group = "test" }
+]
+
+test = [
   "pytest>=9.0.2",
   "pytest-asyncio>=1.3.0",
   "pytest-cov>=7.0.0",
@@ -69,14 +78,6 @@ doc = [
   "sphinxcontrib-video==0.4.2",
 ]
 
-dev = [
-  "ansys-aedt-mcp[tests,doc]",
-  "pre-commit>=4.0",
-  "ruff>=0.11.0",
-  "mypy>=1.8.0",
-  "bandit[toml]>=1.8.0",
-]
-
 [project.urls]
 Documentation = "https://aedt-mcp.docs.pyansys.com"
 Homepage = "https://github.com/ansys/pyaedt-mcp"
@@ -90,32 +91,32 @@ ansys-aedt-mcp = "ansys.aedt.mcp.__main__:launcher"
 name = "ansys.aedt.mcp"
 
 [tool.ruff]
-line-length = 100
 fix = true
 format.indent-style = "space"
 format.quote-style = "double"
-lint.select = [
-  "D",   # pydocstyle
-  "E",   # pycodestyle
-  "F",   # pyflakes
-  "I",   # isort
-  "N",   # pep8-naming
-  "PTH", # flake8-use-pathlib
-  "TD",  # flake8-todos
-]
+line-length = 100
 lint.ignore = [
   "D100", # Missing docstring in public module
   "D104", # Missing docstring in public package
   "D401", # First line of docstring should be in imperative mood
   "TD002", # Missing author in TODO comments
 ]
-lint.per-file-ignores."!src/**.py" = [ "D" ]
-lint.per-file-ignores."__init__.py" = [ "F401" ]
-lint.per-file-ignores."tests/**.py" = [ "D", "E501", "N806" ]
 lint.isort.combine-as-imports = true
 lint.isort.force-sort-within-sections = true
-lint.isort.known-first-party = [ "ansys.aedt.mcp" ]
+lint.isort.known-first-party = ["ansys.aedt.mcp"]
+lint.per-file-ignores."!src/**.py" = ["D"]
+lint.per-file-ignores."__init__.py" = ["F401"]
+lint.per-file-ignores."tests/**.py" = ["D", "E501", "N806"]
 lint.pydocstyle.convention = "numpy"
+lint.select = [
+  "D", # pydocstyle
+  "E", # pycodestyle
+  "F", # pyflakes
+  "I", # isort
+  "N", # pep8-naming
+  "PTH", # flake8-use-pathlib
+  "TD", # flake8-todos
+]
 
 [tool.mypy]
 exclude = [
@@ -146,7 +147,7 @@ testpaths = ["tests"]
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", "venv"]
-skips = ["B101"]  # Skip assert_used in tests
+skips = ["B101"] # Skip assert_used in tests
 
 [tool.uv]
 index-strategy = "unsafe-best-match"


### PR DESCRIPTION
This pull request updates the project's dependency management and CI configuration to use the new PEP 722/PEP 723 dependency group format, and clarifies the maintainers section. The changes improve the structure and maintainability of development, testing, and documentation dependencies, and update the CI workflow to align with these changes.

**Dependency management improvements:**

* Migrated from `[project.optional-dependencies]` to `[dependency-groups]` in `pyproject.toml`, grouping `dev`, `test`, and `doc` dependencies for better organization and maintainability. Now, `dev` includes the `test` and `doc` groups via `include-group`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L54-R64) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L69-R78)


**CI workflow updates:**

* Updated `.github/workflows/ci.yml` to pass the new `group-dependencies-name` argument for the test and documentation jobs, so the workflow installs the correct dependency groups. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR147) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR162)