### PR TITLE
chore: Add "pre-commit" package-ecosystem to ``dependabot.yml``

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,16 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "ansys/pre-commit-hooks"
+    labels:
+      - "maintenance"
+    commit-message:
+      prefix: "build(pre-commit)"


### PR DESCRIPTION
This PR adds the "pre-commit" package-ecosystem to the ``dependabot.yml`` config file, following the recent support brought to dependabot for this (https://github.com/dependabot/dependabot-core/issues/1524).

A cooldown of 7 days excluding the ``ansys/pre-commit-hooks`` is defined, which aligns with the "pip" and "github-actions" package-ecosystems already present in the file.