### PR TITLE
ci: Add ``label.yml`` workflow and automatic changelog feature

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,68 @@
+name: Labeler
+
+on:
+  pull_request:
+      types: [opened, reopened, synchronize, edited, labeled]
+  push:
+    branches: [ main ]
+    paths:
+      - '../labels.yml'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  label-syncer:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to read repository files and .github/labels.yml configuration
+      pull-requests: write # Needed to add existing labels to PRs
+      issues: write        # Needed to create labels that do not already exist
+    steps:
+    - name: Install Git and checkout project
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - name: Sync labels with config from labels.yml
+      uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  labeler:
+    name: Set labels
+    needs: label-syncer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to read repository files and .github/labeler.yml configuration
+      pull-requests: write # Needed to add/modify labels on pull requests
+    steps:
+    - name: Install Git and checkout project
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - name: Add label(s) to PR based on changed files or branch name
+      uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  changelog-fragment:
+    name: Create changelog fragment
+    needs: labeler
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # Required to commit changelog fragments to the repository
+      pull-requests: write  # Required to update PR with changelog information
+    steps:
+    - uses: ansys/actions/doc-changelog@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+      with:
+        bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+        bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+        token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+        use-pull-request-title: true
+        use-default-towncrier-config: true
+        use-python-cache: false

--- a/doc/changelog.d/30.maintenance.md
+++ b/doc/changelog.d/30.maintenance.md
@@ -1,0 +1,1 @@
+Add \`\`label.yml\`\` workflow and automatic changelog feature

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,0 +1,22 @@
+{% if sections[""] %}
+
+.. tab-set::
+
+{%+ for category, val in definitions.items() if category in sections[""] %}
+
+  .. tab-item:: {{ definitions[category]['name'] }}
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
+
+{% for text, values in sections[""][category].items() %}
+        * - {{ text }}
+          - {{ values|join(', ') }}
+
+{% endfor %}
+{% endfor %}
+
+{% else %}
+No significant changes.
+{% endif %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,9 +150,7 @@ linkcheck_ignore = [
 # If we are on a release, we have to ignore the "release" URLs, since it is not
 # available until the release is published.
 if switcher_version != "dev":
-    linkcheck_ignore.append(
-        f"https://github.com/ansys/pyaedt-mcp/releases/tag/v{__version__}"
-    )
+    linkcheck_ignore.append(f"https://github.com/ansys/pyaedt-mcp/releases/tag/v{__version__}")
 
 linkcheck_allowed_redirect = [
     r"https://tox.wiki/",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -147,6 +147,13 @@ linkcheck_ignore = [
     "https://www.sphinx-doc.org/*",
 ]
 
+# If we are on a release, we have to ignore the "release" URLs, since it is not
+# available until the release is published.
+if switcher_version != "dev":
+    linkcheck_ignore.append(
+        f"https://github.com/ansys/pyaedt-mcp/releases/tag/v{__version__}"
+    )
+
 linkcheck_allowed_redirect = [
     r"https://tox.wiki/",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,52 @@ skips = ["B101"] # Skip assert_used in tests
 
 [tool.uv]
 index-strategy = "unsafe-best-match"
+
+[tool.towncrier]
+package = "ansys.aedt.mcp"
+directory = "doc/changelog.d"
+filename = "doc/source/changelog.rst"
+start_string = ".. towncrier release notes start\n"
+template = "doc/changelog.d/changelog_template.jinja"
+title_format = "`{version} <https://github.com/ansys/pyaedt-mcp/releases/tag/v{version}>`_ - {project_date}"
+issue_format = "`#{issue} <https://github.com/ansys/pyaedt-mcp/pull/{issue}>`_"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "maintenance"
+name = "Maintenance"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "test"
+name = "Test"
+showcontent = true


### PR DESCRIPTION
This PR brings a ``label.yml`` workflow to the project with the following jobs: 
* ``label-syncer`` (using the ``micnncim/action-label-syncer`` action) to make the labels defined in the ``labels.yml`` file available on PR,
* ``labeler`` (using the ``actions/labeler`` action) to automatically assign labels to PR based on the configuration defined in ``labeler.yml``,
* ``changelog-fragment`` (using the ``ansys/actions/doc-changelog`` action) to automatically generate an .md file for each PR - these files are stored in the ``doc/changelog.d`` folder and will be aggregated upon each release to generate the release notes (in the ``doc/source/changelog.rst file``). To support that, a ``[tool.towncrier]`` section is defined in the ``pyproject.toml`` file, a check is added to the ``conf.py`` file and the ``doc/changelog.d/changelog_template.jinja`` file is introduced. 