### PR TITLE
ci: Add release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -15,7 +15,7 @@ env:
   MAIN_PYTHON_VERSION: "3.13"
   PACKAGE_NAME: "ansys-aedt-mcp"
   DOCUMENTATION_CNAME: "aedt-mcp.docs.pyansys.com"
-  
+
 jobs:
 
   update-changelog:
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           exit-with-error-on-new-advisory: false
-          
+
   code-style:
     name: "Code style checks"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,216 @@
+name: GitHub CI - Release
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  ON_CI: "true"
+  MAIN_PYTHON_VERSION: "3.13"
+  PACKAGE_NAME: "ansys-aedt-mcp"
+  DOCUMENTATION_CNAME: "aedt-mcp.docs.pyansys.com"
+  
+jobs:
+
+  update-changelog:
+    name: Update CHANGELOG on release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to read and write repository contents
+      pull-requests: write # Needed to create pull requests
+    steps:
+      - uses: ansys/actions/doc-deploy-changelog@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+
+  actions-security:
+    name: "Actions security"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout and scan workflows
+    steps:
+      - uses: ansys/actions/check-actions-security@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          generate-summary: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          auditing-level: 'high'
+
+  vulnerabilities:
+    name: "Vulnerabilities"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the code
+      security-events: write # Needed to create security advisories
+      issues: write # Needed to create issues for new advisories
+    steps:
+      - uses: ansys/actions/check-vulnerabilities@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-package-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          dev-mode: ${{ github.ref != 'refs/heads/main' }}
+          exit-with-error-on-new-advisory: false
+          
+  code-style:
+    name: "Code style checks"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the code
+    steps:
+      - name: "Run PyAnsys code style checks"
+        uses: ansys/actions/code-style@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+  docs-style:
+    name: "Documentation style checks"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the code
+      checks: write # Needed for reviewdog to create check runs
+    steps:
+      - name: "Run Ansys documentation style checks"
+        uses: ansys/actions/doc-style@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+            token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+
+  build-docs:
+    name: "Build documentation"
+    runs-on: ubuntu-latest
+    needs: [docs-style]
+    permissions:
+      contents: read # Needed to checkout the code
+    steps:
+      - name: "Run Ansys documentation building action"
+        uses: ansys/actions/doc-build@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          dependencies: 'zip libgl1 libglx-mesa0 xvfb'
+          sphinxopts: '-W --keep-going'
+          group-dependencies-name: doc
+
+  smoke-tests:
+    name: "Build and smoke tests"
+    runs-on: ${{ matrix.os }}
+    needs: [code-style]
+    permissions:
+      contents: read # Needed to checkout the code
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: "Build wheelhouse and perform smoke test"
+        uses: ansys/actions/build-wheelhouse@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          operating-system: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          whitelist-license-check: 'fpdf2'
+
+  test:
+    name: "Test Python ${{ matrix.python-version }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    needs: [smoke-tests]
+    permissions:
+      contents: read # Needed to checkout the code
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: "Run unit tests"
+        uses: ansys/actions/tests-pytest@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          python-version: ${{ matrix.python-version }}
+          pytest-markers: '-m "not integration"'
+          group-dependencies-name: test
+
+  package:
+    name: "Package library"
+    needs: [test, build-docs]
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write # Required to upload provenance attestations
+      contents: read # Needed to checkout the code
+      id-token: write # Required for OIDC authentication to upload provenance attestations
+    steps:
+      - name: "Build library source and wheel artifacts"
+        uses: ansys/actions/build-library@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          attest-provenance: true
+
+  release:
+    name: "Release project to GitHub"
+    needs: [package, build-docs, update-changelog]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write # Required for GitHub release
+      contents: write # Required for GitHub release
+    steps:
+      - name: "Release to GitHub"
+        uses: ansys/actions/release-github@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          library-name: ${{ env.PACKAGE_NAME }}
+          add-artifact-attestation-notes: true
+          changelog-release-notes: true
+
+      - name: "Release to private PyPI"
+        uses: ansys/actions/release-pypi-private@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
+
+  release-pypi:
+    name: "Release project to public PyPI"
+    needs: [release]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write # Required for OIDC authentication with PyPI
+      contents: write # Required for OIDC authentication with PyPI
+    steps:
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-artifacts
+          path: ${{ env.PACKAGE_NAME }}-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          skip-existing: false
+
+  doc-deploy-stable:
+    name: "Deploy stable documentation"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to push documentation to gh-pages branch
+    needs: [release-pypi]
+    steps:
+      - name: "Deploy the stable documentation"
+        uses: ansys/actions/doc-deploy-stable@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
+        with:
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          render-last: '5'
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI/CD
 on:
   pull_request:
   push:
-    tags:
-      - "v*"
     branches:
       - main
   schedule:
@@ -24,19 +22,59 @@ env:
 
 jobs:
 
-  update-changelog:
-    name: "Update CHANGELOG (on release)"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+  # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
+  # This is to mitigate supply chain attacks, where a malicious dependency update
+  # could execute arbitrary code in our build environment.
+  # Dependabot PRs must be reviewed carefully and approved manually before
+  # running the CI.
+  block-dependabot:
+    name: Block dependabot (on dependabot PR)
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Needed to read and write repository contents
-      pull-requests: write # Needed to create pull requests
     steps:
-      - uses: ansys/actions/doc-deploy-changelog@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
-        with:
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
-          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+      - name: Exit if dependabot triggered the workflow # zizmor: ignore[bot-conditions] safe ignore because we exit if dependabot is triggering the action
+        if: github.triggering_actor == 'dependabot[bot]'
+        run: |
+          echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
+          exit 1
+
+
+  # NOTE: We do not allow the pre-commit-ci bot to trigger the CI/CD pipeline
+  # automatically on PR it creates.
+  # This is to mitigate supply chain attacks, where a malicious dependency update
+  # could execute arbitrary code in our build environment.
+  # PRs opened by the pre-commit-ci bot must be reviewed carefully and approved
+  # manually before running the CI.
+  block-pre-commit-ci-bot-PR:
+    name: Block pre-commit-ci bot (on pre-commit-ci bot PR only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exit if pre-commit-ci bot triggered the workflow # zizmor: ignore[bot-conditions] safe ignore because we exit if pre-commit-ci bot is triggering the action
+        if: github.triggering_actor == 'pre-commit-ci[bot]' && github.event.pull_request.head.ref == 'pre-commit-ci-update-config'
+        run: |
+          echo "::warning::pre-commit-ci bot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
+          exit 1
+
+
+  # NOTE: We do not allow pyansys-ci-bot to trigger the CI/CD pipeline automatically
+  # on dependabot's and pre-commit-ci bot's PR. This is to mitigate supply chain attacks,
+  # where a malicious dependency update could execute arbitrary code in our build environment.
+  # Dependabot and pre-commit-ci bot PRs must be reviewed carefully and approved manually before
+  # running the CI.
+  block-pyansys-ci-bot:
+    name: Block PyAnsys-CI-bot (on dependabot and pre-commit-ci bot PR)
+    needs: [block-dependabot, block-pre-commit-ci-bot-PR]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exit if pyansys-ci-bot triggered the workflow on dependabot's PR
+        if: github.triggering_actor == 'pyansys-ci-bot' && startsWith(github.head_ref, 'dependabot')
+        run: |
+          echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
+          exit 1
+      - name: Exit if pyansys-ci-bot triggered the workflow on pre-commit-ci bot's PR
+        if: github.triggering_actor == 'pyansys-ci-bot' && github.event.pull_request.head.ref == 'pre-commit-ci-update-config'
+        run: |
+          echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in pre-commit-ci bot's PR. Please review carefully the changes before running the workflow manually."
+          exit 1
 
   code-style:
     name: "Code style checks"
@@ -111,13 +149,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        should-release:
-          - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
-        exclude:
-          - should-release: false
-            os: macos-latest
     steps:
       - name: "Build wheelhouse and perform smoke test"
         uses: ansys/actions/build-wheelhouse@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
@@ -175,7 +208,7 @@ jobs:
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          attest-provenance: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
+          attest-provenance: false
 
   doc-deploy-dev:
     name: "Deploy development documentation"
@@ -209,69 +242,3 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           maximum-pr-doc-deployments: 10
-
-  release:
-    name: "Release project to GitHub"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [package, build-docs, update-changelog]
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write # Required for GitHub release
-      contents: write # Required for GitHub release
-    steps:
-      - name: "Release to GitHub"
-        uses: ansys/actions/release-github@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          library-name: ${{ env.PACKAGE_NAME }}
-          add-artifact-attestation-notes: true
-          changelog-release-notes: true
-
-      - name: "Release to private PyPI"
-        uses: ansys/actions/release-pypi-private@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
-        with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
-
-  release-pypi:
-    name: "Release project to public PyPI"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [release]
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write # Required for OIDC authentication with PyPI
-      contents: write # Required for OIDC authentication with PyPI
-    steps:
-      - name: "Download the library artifacts from build-library step"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.PACKAGE_NAME }}-artifacts
-          path: ${{ env.PACKAGE_NAME }}-artifacts
-
-      - name: "Upload artifacts to PyPI using trusted publisher"
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: "https://upload.pypi.org/legacy/"
-          print-hash: true
-          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
-          skip-existing: false
-
-  doc-deploy-stable:
-    name: "Deploy stable documentation"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Needed to push documentation to gh-pages branch
-    needs: [release-pypi]
-    steps:
-      - name: "Deploy the stable documentation"
-        uses: ansys/actions/doc-deploy-stable@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          render-last: '5'
-          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
-          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,60 +22,6 @@ env:
 
 jobs:
 
-  # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
-  # This is to mitigate supply chain attacks, where a malicious dependency update
-  # could execute arbitrary code in our build environment.
-  # Dependabot PRs must be reviewed carefully and approved manually before
-  # running the CI.
-  block-dependabot:
-    name: Block dependabot (on dependabot PR)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Exit if dependabot triggered the workflow # zizmor: ignore[bot-conditions] safe ignore because we exit if dependabot is triggering the action
-        if: github.triggering_actor == 'dependabot[bot]'
-        run: |
-          echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
-          exit 1
-
-
-  # NOTE: We do not allow the pre-commit-ci bot to trigger the CI/CD pipeline
-  # automatically on PR it creates.
-  # This is to mitigate supply chain attacks, where a malicious dependency update
-  # could execute arbitrary code in our build environment.
-  # PRs opened by the pre-commit-ci bot must be reviewed carefully and approved
-  # manually before running the CI.
-  block-pre-commit-ci-bot-PR:
-    name: Block pre-commit-ci bot (on pre-commit-ci bot PR only)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Exit if pre-commit-ci bot triggered the workflow # zizmor: ignore[bot-conditions] safe ignore because we exit if pre-commit-ci bot is triggering the action
-        if: github.triggering_actor == 'pre-commit-ci[bot]' && github.event.pull_request.head.ref == 'pre-commit-ci-update-config'
-        run: |
-          echo "::warning::pre-commit-ci bot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
-          exit 1
-
-
-  # NOTE: We do not allow pyansys-ci-bot to trigger the CI/CD pipeline automatically
-  # on dependabot's and pre-commit-ci bot's PR. This is to mitigate supply chain attacks,
-  # where a malicious dependency update could execute arbitrary code in our build environment.
-  # Dependabot and pre-commit-ci bot PRs must be reviewed carefully and approved manually before
-  # running the CI.
-  block-pyansys-ci-bot:
-    name: Block PyAnsys-CI-bot (on dependabot and pre-commit-ci bot PR)
-    needs: [block-dependabot, block-pre-commit-ci-bot-PR]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Exit if pyansys-ci-bot triggered the workflow on dependabot's PR
-        if: github.triggering_actor == 'pyansys-ci-bot' && startsWith(github.head_ref, 'dependabot')
-        run: |
-          echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
-          exit 1
-      - name: Exit if pyansys-ci-bot triggered the workflow on pre-commit-ci bot's PR
-        if: github.triggering_actor == 'pyansys-ci-bot' && github.event.pull_request.head.ref == 'pre-commit-ci-update-config'
-        run: |
-          echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in pre-commit-ci bot's PR. Please review carefully the changes before running the workflow manually."
-          exit 1
-
   code-style:
     name: "Code style checks"
     runs-on: ubuntu-latest

--- a/doc/changelog.d/31.maintenance.md
+++ b/doc/changelog.d/31.maintenance.md
@@ -1,0 +1,1 @@
+Add release workflow


### PR DESCRIPTION
This PR is introducing a dedicated release workflow (``.github/workflows/ci-release.yml``) to improve the structure, readability and maintainability of the CI. 
It basically reproduces the behavior implemented up to now in the ``ci.yml`` workflow when the condition ``github.event_name == 'push' && contains(github.ref, 'refs/tags')`` was met.

Consequently, the ``ci.yml`` workflow (triggered on PR, as well as upon push on branch ``main`` and also scheduled to run daily) is slightly simplified: Strictly release-related jobs are removed and a few conditions within certain jobs are dropped.