### PR TITLE
fix: drop Python 3.11 support and bump ansys-common-mcp to 0.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -65,7 +65,6 @@ body:
       description: Run `python --version` to verify your Python version.
       multiple: false
       options:
-       - '3.11'
        - '3.12'
        - '3.13'
        - '3.14'

--- a/.github/ISSUE_TEMPLATE/examples.yml
+++ b/.github/ISSUE_TEMPLATE/examples.yml
@@ -46,7 +46,6 @@ body:
       description: Run `python --version` to verify your Python version.
       multiple: false
       options:
-       - '3.11'
        - '3.12'
        - '3.13'
        - '3.14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   ON_CI: True
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10
-  MAIN_PYTHON_VERSION: "3.11"
+  MAIN_PYTHON_VERSION: "3.14"
   TESTS_PYTHON_VERSION: "3.12"
   PACKAGE_NAME: "ansys-aedt-mcp"
   DOCUMENTATION_CNAME: "aedt-mcp.docs.pyansys.com"
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: "Build wheelhouse and perform smoke test"
         uses: ansys/actions/build-wheelhouse@7419880d64bb0bba83f968ca803611df0b76faf0 #v10.3.4
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: "Run unit tests"
         uses: ansys/actions/tests-pytest@7419880d64bb0bba83f968ca803611df0b76faf0 #v10.3.4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 [![PyAnsys](https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC)](https://docs.pyansys.com/)
-[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/)
 [![License: Apache%202.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
@@ -64,7 +64,7 @@ pre-commit install
 
 ## Requirements
 
-- Python 3.11 or later
+- Python 3.12 or later
 - AEDT 2022 R2 or later for gRPC workflows
 - A local AEDT installation or a reachable remote AEDT gRPC endpoint
 

--- a/doc/changelog.d/68.fixed.md
+++ b/doc/changelog.d/68.fixed.md
@@ -1,0 +1,1 @@
+Drop Python 3.11 support and bump ansys-common-mcp to 0.3.3

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -11,7 +11,7 @@ You can run PyAEDT-MCP in two modes:
 Check prerequisites
 -------------------
 
-- Python 3.11 or later
+- Python 3.12 or later
 - AEDT 2022 R2 or later for gRPC workflows
 - A local AEDT installation or a reachable remote AEDT endpoint
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -40,7 +39,7 @@ license-files = ["LICENSE"]
 maintainers = [{name = "Synopsys, Inc. and ANSYS, Inc.", email = "pyansys-core@synopsys.com"}]
 name = "ansys-aedt-mcp"
 readme = "README.md"
-requires-python = ">=3.11,<4"
+requires-python = ">=3.12,<4"
 version = "0.1.dev0"
 
 dependencies = [
@@ -63,7 +62,7 @@ doc = [
   "sphinxcontrib-video==0.4.2",
 ]
 tests = [
-  "ansys-common-mcp==0.3.2",
+  "ansys-common-mcp==0.3.3",
   "matplotlib==3.11.0",
   "pyaedt==1.2.0",
   "pytest==9.1.1",
@@ -118,7 +117,7 @@ explicit_package_bases = true
 ignore_missing_imports = true
 mypy_path = "src"
 namespace_packages = true
-python_version = "3.11"
+python_version = "3.14"
 warn_unused_configs = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Issues found

1. **Dependency resolution risk**: `ansys-common-mcp==0.3.2` is exact-pinned in the `tests` dependency group. That version has an unbounded `fastmcp`/`mcp` dependency, which can let pip resolve `mcp==2.0.0` (a breaking release) alongside an incompatible older `fastmcp`. That combination causes either `ModuleNotFoundError: No module named 'pydantic_settings'` or `ImportError: cannot import name 'McpError'` at import time.
2. **Python 3.11 still listed as supported**, despite `ansys-common-mcp` (a required dependency) already requiring Python 3.12+.

## Fixes

1. Bump `ansys-common-mcp` from `0.3.2` to `0.3.3` in the `tests` dependency group. `0.3.3` requires `fastmcp>=3.0.0` and `pydantic-settings>=2.0.0` directly, which prevents the broken `mcp==2.0.0` + old-`fastmcp` pairing from ever being resolved. The main `dependencies` list already used an unbounded `ansys-common-mcp>=0.3.0`, so only the exact test pin needed changing.
2. Drop Python 3.11 support (3.12–3.14 only):
   - `pyproject.toml`: `requires-python`, classifiers, `tool.mypy.python_version`
   - `.github/workflows/ci.yml`: `MAIN_PYTHON_VERSION`, smoke-tests matrix, test matrix
   - `README.md`: Python badge and prerequisite line
   - `doc/source/getting_started/installation.rst`: prerequisite line
   - `.github/ISSUE_TEMPLATE/bug.yml` and `examples.yml`: Python version dropdown options

## Validation

- `uv lock` resolves cleanly: `ansys-common-mcp==0.3.3`, `fastmcp==3.4.5`, `mcp==1.29.0` (not `2.0.0`), `pydantic-settings==2.14.2` present
- `pytest -m "not integration and not system"` passes (92% coverage, no failures)
- Repo-wide sweep confirms no remaining Python 3.11 references outside of an unrelated `matplotlib==3.11.0` version pin
