### PR TITLE
fix: Update pyaedt dependency and refactor session info handling

### DIFF
--- a/doc/changelog.d/72.fixed.md
+++ b/doc/changelog.d/72.fixed.md
@@ -1,0 +1,1 @@
+Update pyaedt dependency and refactor session info handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ version = "0.1.dev0"
 
 dependencies = [
   "pyaedt>=1.3.0",
-  "ansys-common-mcp>=0.3.0",
+  "ansys-common-mcp>=0.3.3",
   "ansys-tools-visualization-interface",
   "pyvista[io]>=0.38.0,<0.49",
-  "matplotlib>=3.5.0",
+  "matplotlib>=3.11.0",
   "vtk>=9.0,<9.7",
   "pillow",
 ]
@@ -62,9 +62,6 @@ doc = [
   "sphinxcontrib-video==0.4.2",
 ]
 tests = [
-  "ansys-common-mcp==0.3.3",
-  "matplotlib==3.11.0",
-  "pyaedt==1.2.0",
   "pytest==9.1.1",
   "pytest-asyncio==1.4.0",
   "pytest-cov==7.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires-python = ">=3.12,<4"
 version = "0.1.dev0"
 
 dependencies = [
-  "pyaedt>=1.0.0",
+  "pyaedt>=1.3.0",
   "ansys-common-mcp>=0.3.0",
   "ansys-tools-visualization-interface",
   "pyvista[io]>=0.38.0,<0.49",

--- a/src/ansys/aedt/mcp/helpers.py
+++ b/src/ansys/aedt/mcp/helpers.py
@@ -20,6 +20,7 @@ This module provides utility functions for working with AEDT
 instances and extracting information from them.
 """
 
+from dataclasses import asdict
 from pathlib import Path
 import socket
 from typing import Any
@@ -73,7 +74,7 @@ def discover_available_aedt_sessions() -> list[dict[str, Any]]:
     sessions = _discover_aedt_sessions()
     normalized_sessions = []
     for session_info in sessions:
-        normalized = dict(session_info)
+        normalized = asdict(session_info)
         normalized["connectable"] = (
             normalized.get("mode") == "grpc" and normalized.get("port") is not None
         )

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -17,6 +17,7 @@
 """Additional unit tests for helper and startup modules."""
 
 import builtins
+from dataclasses import dataclass
 from pathlib import Path
 import runpy
 import sys
@@ -171,24 +172,33 @@ def test_probe_grpc_endpoint_unreachable(monkeypatch):
 
 
 def test_discover_available_aedt_sessions_uses_pyaedt_cli(monkeypatch):
+    @dataclass
+    class _SessionInfo:
+        pid: int
+        port: int | None
+        mode: str
+        version: str
+        non_graphical: bool
+        student_version: bool
+
     cli_module = ModuleType("ansys.aedt.core.cli.aedt")
     cli_module._discover_aedt_sessions = lambda: [
-        {
-            "pid": 101,
-            "port": 50051,
-            "mode": "grpc",
-            "version": "2026.1",
-            "non_graphical": True,
-            "student_version": False,
-        },
-        {
-            "pid": 202,
-            "port": None,
-            "mode": "com",
-            "version": "2025.2",
-            "non_graphical": False,
-            "student_version": False,
-        },
+        _SessionInfo(
+            pid=101,
+            port=50051,
+            mode="grpc",
+            version="2026.1",
+            non_graphical=True,
+            student_version=False,
+        ),
+        _SessionInfo(
+            pid=202,
+            port=None,
+            mode="com",
+            version="2025.2",
+            non_graphical=False,
+            student_version=False,
+        ),
     ]
 
     monkeypatch.setitem(sys.modules, "ansys.aedt.core.cli.aedt", cli_module)


### PR DESCRIPTION
Upgrade the pyaedt dependency to version 1.3.0 and refactor the handling of session information in tests by utilizing a dataclass for fixing the bug