### PR TITLE
feat: Added validation check

### DIFF
--- a/doc/changelog.d/91.added.md
+++ b/doc/changelog.d/91.added.md
@@ -1,0 +1,1 @@
+Added validation check

--- a/doc/source/examples/hfss_patch_antenna_workflow.rst
+++ b/doc/source/examples/hfss_patch_antenna_workflow.rst
@@ -32,7 +32,7 @@ reduces token cost.
        ``get_guidelines_for``
    * - After ``launch_aedt`` or ``connect_to_aedt``
      - ``check_aedt_status``, ``create_design``, ``open_project``,
-        ``save_project``, ``validate_design``, ``analyze_design``, ``screenshot``,
+       ``save_project``, ``validate_design``, ``analyze_design``, ``screenshot``,
        ``run_python_code``, ``run_python_script``, and related tools
 
 The tool set expands automatically as part of the launch or connect call

--- a/doc/source/examples/hfss_patch_antenna_workflow.rst
+++ b/doc/source/examples/hfss_patch_antenna_workflow.rst
@@ -32,7 +32,7 @@ reduces token cost.
        ``get_guidelines_for``
    * - After ``launch_aedt`` or ``connect_to_aedt``
      - ``check_aedt_status``, ``create_design``, ``open_project``,
-       ``save_project``, ``analyze_design``, ``screenshot``,
+        ``save_project``, ``validate_design``, ``analyze_design``, ``screenshot``,
        ``run_python_code``, ``run_python_script``, and related tools
 
 The tool set expands automatically as part of the launch or connect call
@@ -227,16 +227,11 @@ Create setup and frequency sweep
        name="Sweep1"
    )
 
-   # Validate design
-   valid = hfss.validate_full_design()
-
-   result = "Setup and sweep created. Setup: {}, Sweep: Sweep1, Valid: {}".format(
-       setup.name, valid[1] if isinstance(valid, tuple) else valid
-   )
+   result = "Setup and sweep created. Setup: {}, Sweep: Sweep1".format(setup.name)
 
 .. code-block:: text
 
-   Response: Setup and sweep created. Setup: Setup1, Sweep: Sweep1, Valid: True
+   Response: Setup and sweep created. Setup: Setup1, Sweep: Sweep1
 
 Capture pre-solve screenshot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -245,6 +240,20 @@ Capture pre-solve screenshot
 
 The tool returns a PNG file of the AEDT viewport showing the antenna
 geometry.
+
+Validate design
+~~~~~~~~~~~~~~~
+
+**Tool:** ``validate_design``
+
+Run this tool after design/setup changes and before solving.
+
+.. code-block:: text
+
+   Response:
+     Design validation passed.
+     Project: Project6
+     Design: PatchAntenna_Validation
 
 Solve design
 ~~~~~~~~~~~~

--- a/doc/source/user_guide/tools_and_capabilities.rst
+++ b/doc/source/user_guide/tools_and_capabilities.rst
@@ -59,7 +59,7 @@ these tools are hidden again.
    * - ``create_design``
      - Create a new design (HFSS, Maxwell, Icepak, Circuit, and so on).
    * - ``validate_design``
-      - Run design validation checks before solving.
+     - Run design validation checks before solving.
    * - ``analyze_design``
      - Run the configured solver analysis on the active design.
    * - ``export_config``
@@ -199,7 +199,7 @@ server indefinitely.
    * - Medium
      - 120 seconds
      - ``launch_aedt``, ``connect_to_aedt``, ``disconnect_from_aedt``,
-        ``open_project``, ``save_project``, ``create_design``, ``validate_design``,
+       ``open_project``, ``save_project``, ``create_design``, ``validate_design``,
        ``screenshot``, ``clear_aedt``, and ``export_config``
    * - Long
      - 600 s

--- a/doc/source/user_guide/tools_and_capabilities.rst
+++ b/doc/source/user_guide/tools_and_capabilities.rst
@@ -58,6 +58,8 @@ these tools are hidden again.
      - Save the active project to disk.
    * - ``create_design``
      - Create a new design (HFSS, Maxwell, Icepak, Circuit, and so on).
+   * - ``validate_design``
+      - Run design validation checks before solving.
    * - ``analyze_design``
      - Run the configured solver analysis on the active design.
    * - ``export_config``
@@ -138,6 +140,11 @@ and run them with ``run_python_code``.
 Run an analysis
 ~~~~~~~~~~~~~~~
 
+Run design validation before starting a solve, especially after geometry,
+boundary, setup, or sweep changes.
+
+*"Validate the active design before solving."*
+
 *"Analyze the active design."*
 
 *"Run setup 'Setup1' on the active design."*
@@ -192,7 +199,7 @@ server indefinitely.
    * - Medium
      - 120 seconds
      - ``launch_aedt``, ``connect_to_aedt``, ``disconnect_from_aedt``,
-       ``open_project``, ``save_project``, ``create_design``,
+        ``open_project``, ``save_project``, ``create_design``, ``validate_design``,
        ``screenshot``, ``clear_aedt``, and ``export_config``
    * - Long
      - 600 s

--- a/doc/source/user_guide/workflows.rst
+++ b/doc/source/user_guide/workflows.rst
@@ -19,6 +19,7 @@ Maxwell motor analysis
 #. Create a design with ``create_design`` and ``app_type="Maxwell3d"``.
 #. Run ``run_python_code`` to build the motor geometry and assign materials.
 #. Run ``run_python_code`` to assign windings, excitations, and motion setup.
+#. Run ``validate_design`` to catch model/setup issues before solving.
 #. Run ``analyze_design`` to analyze your design.
 #. Run ``run_python_code`` to create a torque and speed report.
 
@@ -29,6 +30,7 @@ Icepak thermal analysis
 #. Create a design with ``create_design`` and ``app_type="Icepak"``.
 #. Run ``run_python_code`` to create the PCB, components, and heat sources.
 #. Run ``run_python_code`` to assign boundary conditions.
+#. Run ``validate_design`` to catch model/setup issues before solving.
 #. Run ``analyze_design`` to analyze your design.
 #. Run ``run_python_code`` to create a temperature contour plot.
 #. Run ``export_results`` to export the simulation results.

--- a/src/ansys/aedt/mcp/prompts.py
+++ b/src/ansys/aedt/mcp/prompts.py
@@ -58,7 +58,7 @@ you can plan workflows before connecting.
 
 - Lifecycle: `disconnect_from_aedt`
 - Project/design: `list_designs`, `list_projects`, `open_project`,
-  `save_project`, `create_design`, `analyze_design`
+  `save_project`, `create_design`, `validate_design`, `analyze_design`
 - Execution: `run_python_script`, `run_python_code`
 - Export/inspection: `export_results`, `screenshot`, `export_config`,
   `get_model_info`
@@ -86,10 +86,13 @@ you can plan workflows before connecting.
 4. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code
    directly and prefer `run_python_code` over `run_python_script` unless the
    user already has a script file.
-5. Before code intended for `run_python_code`, include
+5. When the user asks to build, modify, or troubleshoot a specific design,
+   call `validate_design` programmatically after design changes and before
+   calling `analyze_design`.
+6. Before code intended for `run_python_code`, include
    `from ansys.aedt.core import settings`, set `settings.release_on_exception = False`
    and `settings.pyedb_use_grpc = True`.
-6. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
+7. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
    `Icepak`, `Circuit`, `Q3d`, `Q2d`, `TwinBuilder`, `Mechanical`, `Emit`, `RMXprt`,
    `Hfss3dLayout`.
 """
@@ -126,6 +129,7 @@ call depends on whether an AEDT session is connected.
 - `open_project`: Open an existing project.
 - `save_project`: Save the current project.
 - `create_design`: Create a new design in the current project.
+- `validate_design`: Run AEDT design validation checks without solving.
 - `analyze_design`: Run the analysis for the current design.
 - Execution: `run_python_script`, `run_python_code`
 - Export/inspection: `export_results`, `screenshot`, `export_config`,
@@ -154,10 +158,13 @@ call depends on whether an AEDT session is connected.
 4. If the MCP lacks a tool for the requested AEDT step, write PyAEDT code
    directly and prefer `run_python_code` over `run_python_script` unless the
    user already has a script file.
-5. Before code intended for `run_python_code`, include
+5. When the user asks to build, modify, or troubleshoot a specific design,
+   call `validate_design` programmatically after design changes and before
+   calling `analyze_design`.
+6. Before code intended for `run_python_code`, include
    `from ansys.aedt.core import settings`, set `settings.release_on_exception = False`
    and `settings.pyedb_use_grpc = True`.
-6. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
+7. Use the correct PyAEDT app class for the solver: `Hfss`, `Maxwell3d`, `Maxwell2d`,
    `Icepak`, `Circuit`, `Q3d`, `Q2d`, `TwinBuilder`, `Mechanical`, `Emit`, `RMXprt`,
    `Hfss3dLayout`.
 """

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -1257,6 +1257,13 @@ def analyze_design(
             setup_name or "all setups",
         )
 
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            validation_log_file = Path(temporary_directory) / "validation.log"
+            if not app_instance.validate_simple(log_file=validation_log_file):
+                if validation_log_file.is_file():
+                    return validation_log_file.read_text(encoding="utf-8", errors="replace")
+                return "Design validation failed."
+
         result = app_instance.analyze(
             setup=setup_name,
             cores=num_cores,

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -693,9 +693,9 @@ async def connect_to_aedt(
         except TypeError:
             open_projects = []
 
-        connected_app = None
+        aedt_app = None
         if design_name is not None:
-            connected_app = get_pyaedt_app(
+            aedt_app = get_pyaedt_app(
                 project_name=project_name,
                 design_name=design_name,
                 desktop=desktop,
@@ -712,11 +712,11 @@ async def connect_to_aedt(
             f"Version: {desktop.aedt_version_id}\n"
             f"gRPC Mode: {desktop.is_grpc_api}\n"
         )
-        if connected_app is not None:
+        if aedt_app is not None:
             message += (
-                f"Project: {connected_app.project_name}\n"
-                f"Design: {connected_app.design_name}\n"
-                f"Application: {connected_app.design_type}\n"
+                f"Project: {aedt_app.project_name}\n"
+                f"Design: {aedt_app.design_name}\n"
+                f"Application: {aedt_app.design_type}\n"
             )
         elif not open_projects:
             message += (
@@ -1191,34 +1191,34 @@ def validate_design(
     try:
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app(
+        aedt_app = get_pyaedt_app(
             project_name=project_name,
             design_name=design_name,
             desktop=desktop,
         )
 
-        resolved_project_name = app_instance.project_name or project_name
-        resolved_design_name = app_instance.design_name or design_name
+        resolved_project_name = aedt_app.project_name or project_name
+        resolved_design_name = aedt_app.design_name or design_name
 
         logger.info(
             "Validating design project=%s design=%s",
-            resolved_project_name or app_instance.project_name or "active project",
-            resolved_design_name or app_instance.design_name or "active design",
+            resolved_project_name or aedt_app.project_name or "active project",
+            resolved_design_name or aedt_app.design_name or "active design",
         )
 
-        validation_error = _validate_active_design(app_instance)
+        validation_error = _validate_active_design(aedt_app)
         if validation_error is not None:
             return (
                 "Design validation failed.\n"
-                f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
-                f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}\n"
+                f"Project: {resolved_project_name or aedt_app.project_name or 'Unknown'}\n"
+                f"Design: {resolved_design_name or aedt_app.design_name or 'Unknown'}\n"
                 f"Details:\n{validation_error}"
             )
 
         return (
             "Design validation passed.\n"
-            f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
-            f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}"
+            f"Project: {resolved_project_name or aedt_app.project_name or 'Unknown'}\n"
+            f"Design: {resolved_design_name or aedt_app.design_name or 'Unknown'}"
         )
 
     except Exception as e:
@@ -1318,27 +1318,27 @@ def analyze_design(
 
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app(
+        aedt_app = get_pyaedt_app(
             project_name=project_name,
             design_name=design_name,
             desktop=desktop,
         )
 
-        resolved_project_name = app_instance.project_name or project_name
-        resolved_design_name = app_instance.design_name or design_name
+        resolved_project_name = aedt_app.project_name or project_name
+        resolved_design_name = aedt_app.design_name or design_name
 
         logger.info(
             "Running design analysis on project=%s design=%s setup=%s",
-            resolved_project_name or app_instance.project_name or "active project",
-            resolved_design_name or app_instance.design_name or "active design",
+            resolved_project_name or aedt_app.project_name or "active project",
+            resolved_design_name or aedt_app.design_name or "active design",
             setup_name or "all setups",
         )
 
-        validation_error = _validate_active_design(app_instance)
+        validation_error = _validate_active_design(aedt_app)
         if validation_error is not None:
             return validation_error
 
-        result = app_instance.analyze(
+        result = aedt_app.analyze(
             setup=setup_name,
             cores=num_cores,
             tasks=num_tasks,
@@ -1355,15 +1355,15 @@ def analyze_design(
         if not result:
             return (
                 "Analysis failed.\n"
-                f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
-                f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}\n"
+                f"Project: {resolved_project_name or aedt_app.project_name or 'Unknown'}\n"
+                f"Design: {resolved_design_name or aedt_app.design_name or 'Unknown'}\n"
                 f"Setup: {setup_name or 'all setups'}"
             )
 
         return (
             "Analysis started successfully and is running asynchronously.\n"
-            f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
-            f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}\n"
+            f"Project: {resolved_project_name or aedt_app.project_name or 'Unknown'}\n"
+            f"Design: {resolved_design_name or aedt_app.design_name or 'Unknown'}\n"
             f"Setup: {setup_name or 'all setups'}\n"
             f"Mode: {'batch' if solve_in_batch else 'interactive'}\n"
             f"Result: {result}\n"
@@ -1413,14 +1413,14 @@ def export_results(
         try:
             from ansys.aedt.core import get_pyaedt_app
 
-            app_instance = get_pyaedt_app(desktop=desktop)
+            aedt_app = get_pyaedt_app(desktop=desktop)
         except Exception as resolve_error:
             logger.info("Unable to resolve active design for export: %s", resolve_error)
             return (
                 "Export functionality requires an active application. "
                 "Connect to a design or provide an active design context first."
             )
-        if app_instance is None:
+        if aedt_app is None:
             return (
                 "Export functionality requires an active application. "
                 "Connect to a design or provide an active design context first."
@@ -1431,32 +1431,27 @@ def export_results(
             setup_kwargs["setup"] = setup_name
 
         if export_type == "touchstone":
-            if not hasattr(app_instance, "export_touchstone"):
-                return (
-                    f"Touchstone export is not available for {type(app_instance).__name__} designs."
-                )
-            result = app_instance.export_touchstone(output_file=output_path, **setup_kwargs)
+            if not hasattr(aedt_app, "export_touchstone"):
+                return f"Touchstone export is not available for {type(aedt_app).__name__} designs."
+            result = aedt_app.export_touchstone(output_file=output_path, **setup_kwargs)
             return f"Touchstone exported to: {output_path}\nResult: {result}"
 
         elif export_type == "profile":
-            if not hasattr(app_instance, "export_profile"):
-                return f"Profile export is not available for {type(app_instance).__name__} designs."
-            result = app_instance.export_profile(output_file=output_path, **setup_kwargs)
+            if not hasattr(aedt_app, "export_profile"):
+                return f"Profile export is not available for {type(aedt_app).__name__} designs."
+            result = aedt_app.export_profile(output_file=output_path, **setup_kwargs)
             return f"Profile exported to: {output_path}\nResult: {result}"
 
         elif export_type == "convergence":
-            if not hasattr(app_instance, "export_convergence"):
-                return (
-                    "Convergence export is not available for "
-                    f"{type(app_instance).__name__} designs."
-                )
-            result = app_instance.export_convergence(output_file=output_path, **setup_kwargs)
+            if not hasattr(aedt_app, "export_convergence"):
+                return f"Convergence export is not available for {type(aedt_app).__name__} designs."
+            result = aedt_app.export_convergence(output_file=output_path, **setup_kwargs)
             return f"Convergence data exported to: {output_path}\nResult: {result}"
 
         elif export_type == "mesh":
-            if not hasattr(app_instance, "export_mesh_stats"):
-                return f"Mesh export is not available for {type(app_instance).__name__} designs."
-            result = app_instance.export_mesh_stats(output_file=output_path, **setup_kwargs)
+            if not hasattr(aedt_app, "export_mesh_stats"):
+                return f"Mesh export is not available for {type(aedt_app).__name__} designs."
+            result = aedt_app.export_mesh_stats(output_file=output_path, **setup_kwargs)
             return f"Mesh stats exported to: {output_path}\nResult: {result}"
 
         else:
@@ -1530,7 +1525,7 @@ def screenshot(
         try:
             from ansys.aedt.core import get_pyaedt_app
 
-            app_instance = get_pyaedt_app(
+            aedt_app = get_pyaedt_app(
                 project_name=project,
                 design_name=design,
                 desktop=desktop,
@@ -1546,7 +1541,7 @@ def screenshot(
 
         # Export image as JPG
         try:
-            app_instance.post.export_model_picture(
+            aedt_app.post.export_model_picture(
                 full_name=output_path,
                 width=width,
                 height=height,
@@ -1574,8 +1569,8 @@ def screenshot(
 
         status_lines = [
             f"Screenshot saved to '{output_path}'",
-            f"Design: {app_instance.design_name}",
-            f"Project: {app_instance.project_name}",
+            f"Design: {aedt_app.design_name}",
+            f"Project: {aedt_app.project_name}",
         ]
         if open_viewer:
             status_lines.append(viewer_message or "Opened screenshot in the default image viewer.")
@@ -1635,7 +1630,7 @@ def export_config(
     try:
         from ansys.aedt.core import get_pyaedt_app
 
-        app_instance = get_pyaedt_app(
+        aedt_app = get_pyaedt_app(
             project_name=project,
             design_name=design,
             desktop=desktop,
@@ -1649,7 +1644,7 @@ def export_config(
             Path(config_target).unlink()
             temp_config_file = config_target
 
-        config_file = app_instance.configurations.export_config(
+        config_file = aedt_app.configurations.export_config(
             config_file=config_target, overwrite=overwrite
         )
         if not config_file:
@@ -1660,8 +1655,8 @@ def export_config(
 
         data: dict[str, Any] = {
             "config": config_content,
-            "design": app_instance.design_name,
-            "project": app_instance.project_name,
+            "design": aedt_app.design_name,
+            "project": aedt_app.project_name,
         }
         if output:
             data["config_file"] = config_file

--- a/src/ansys/aedt/mcp/tools.py
+++ b/src/ansys/aedt/mcp/tools.py
@@ -1150,6 +1150,83 @@ def create_design(
         return error_msg
 
 
+def _validate_active_design(app_instance: Any) -> str | None:
+    """Run ``validate_simple`` and return error details when validation fails."""
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        validation_log_file = Path(temporary_directory) / "validation.log"
+        if not app_instance.validate_simple(log_file=validation_log_file):
+            if validation_log_file.is_file():
+                return validation_log_file.read_text(encoding="utf-8", errors="replace")
+            return "Design validation failed."
+    return None
+
+
+@app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_MEDIUM)
+def validate_design(
+    ctx: Context,
+    project_name: str | None = None,
+    design_name: str | None = None,
+) -> str:
+    """Validate an AEDT design without starting a solve.
+
+    Parameters
+    ----------
+    ctx : Context
+        MCP context containing server session and application context.
+    project_name : str, default: None
+        Name of the project to validate. If ``None``, the active project is used.
+    design_name : str, default: None
+        Name of the design to validate. If ``None``, the active design is used.
+
+    Returns
+    -------
+    str
+        Validation status and details from AEDT validation logs when available.
+    """
+    desktop = ctx.request_context.lifespan_context.desktop
+
+    if desktop is None:
+        return "No AEDT connection is available. Use connect_to_aedt or launch_aedt first."
+
+    try:
+        from ansys.aedt.core import get_pyaedt_app
+
+        app_instance = get_pyaedt_app(
+            project_name=project_name,
+            design_name=design_name,
+            desktop=desktop,
+        )
+
+        resolved_project_name = app_instance.project_name or project_name
+        resolved_design_name = app_instance.design_name or design_name
+
+        logger.info(
+            "Validating design project=%s design=%s",
+            resolved_project_name or app_instance.project_name or "active project",
+            resolved_design_name or app_instance.design_name or "active design",
+        )
+
+        validation_error = _validate_active_design(app_instance)
+        if validation_error is not None:
+            return (
+                "Design validation failed.\n"
+                f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
+                f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}\n"
+                f"Details:\n{validation_error}"
+            )
+
+        return (
+            "Design validation passed.\n"
+            f"Project: {resolved_project_name or app_instance.project_name or 'Unknown'}\n"
+            f"Design: {resolved_design_name or app_instance.design_name or 'Unknown'}"
+        )
+
+    except Exception as e:
+        error_msg = f"Error during design validation: {str(e)}"
+        logger.error(error_msg)
+        return error_msg
+
+
 @app.tool(tags={"aedt_tools", REQUIRES_AEDT_TAG}, timeout=_TIMEOUT_LONG)
 def analyze_design(
     ctx: Context,
@@ -1257,12 +1334,9 @@ def analyze_design(
             setup_name or "all setups",
         )
 
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            validation_log_file = Path(temporary_directory) / "validation.log"
-            if not app_instance.validate_simple(log_file=validation_log_file):
-                if validation_log_file.is_file():
-                    return validation_log_file.read_text(encoding="utf-8", errors="replace")
-                return "Design validation failed."
+        validation_error = _validate_active_design(app_instance)
+        if validation_error is not None:
+            return validation_error
 
         result = app_instance.analyze(
             setup=setup_name,

--- a/src/ansys/aedt/mcp/toolsets.py
+++ b/src/ansys/aedt/mcp/toolsets.py
@@ -92,11 +92,15 @@ _TOOLSET_CATALOGUE: dict[str, dict[str, Any]] = {
     "simulation": {
         "description": ("Tools for configuring and running AEDT solver analyses."),
         "skill": (
+            "Use validate_design to run AEDT design checks before solving, "
+            "especially after creating or modifying a specific design. "
             "Use analyze_design to run a configured setup/sweep on the "
-            "active design. Use export_config to persist the current setup "
-            "and sweep configuration for reproducibility or sharing."
+            "active design after validation passes. Use export_config to "
+            "persist the current setup and sweep configuration for "
+            "reproducibility or sharing."
         ),
         "tools": [
+            "validate_design",
             "analyze_design",
             "export_config",
         ],

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -27,6 +27,7 @@ def test_build_system_prompt_defaults_to_static_surface_language():
     prompt = build_system_prompt()
 
     assert "exposes the full tool surface from startup" in prompt
+    assert "validate_design" in prompt
     assert "call depends on whether an AEDT session is connected" not in prompt
 
 
@@ -40,6 +41,7 @@ def test_build_system_prompt_dynamic_discovery_language():
     assert "uses connection-aware tool visibility" in prompt
     assert "Unlocked automatically once `launch_aedt` or `connect_to_aedt` succeeds" in prompt
     assert "First call `check_aedt_status`" in prompt
+    assert "call `validate_design` programmatically" in prompt
     assert "include the option to open a new session instead" in prompt
     assert "launch_aedt(confirm_new_session=True)" in prompt
     assert "skip the question and call" in prompt

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -951,6 +951,7 @@ class TestAnalyzeDesign:
         mock_app = MagicMock()
         mock_app.project_name = "Project1"
         mock_app.design_name = "Design1"
+        mock_app.validate_simple.return_value = 1
         mock_app.analyze.return_value = True
 
         with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app) as mock_get_app:
@@ -994,6 +995,27 @@ class TestAnalyzeDesign:
         assert "Design: Design1" in result
         assert "Setup: Setup1" in result
         assert "Mode: batch" in result
+        mock_app.validate_simple.assert_called_once()
+
+    def test_analyze_design_stops_when_validation_fails(self, mock_context):
+        """Test validation failures are reported without starting analysis."""
+        from ansys.aedt.mcp.tools import analyze_design
+
+        mock_app = MagicMock()
+        mock_app.project_name = "Project1"
+        mock_app.design_name = "Design1"
+
+        def write_validation_log(log_file):
+            Path(log_file).write_text("Error: Missing boundary condition", encoding="utf-8")
+            return 0
+
+        mock_app.validate_simple.side_effect = write_validation_log
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = analyze_design(mock_context, setup_name="Setup1")
+
+        mock_app.analyze.assert_not_called()
+        assert result == "Error: Missing boundary condition"
 
     def test_analyze_design_can_run_desktop_analyze_all(self, mock_context):
         """Test explicit desktop-wide analysis path."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -941,6 +941,55 @@ class TestScreenshot:
 
 
 @pytest.mark.unit
+class TestValidateDesign:
+    """Tests for validate_design tool."""
+
+    def test_validate_design_success(self, mock_context):
+        """Validation passes when AEDT reports no errors."""
+        from ansys.aedt.mcp.tools import validate_design
+
+        mock_app = MagicMock()
+        mock_app.project_name = "Project1"
+        mock_app.design_name = "Design1"
+        mock_app.validate_simple.return_value = True
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = validate_design(mock_context, project_name="Project1", design_name="Design1")
+
+        assert "Design validation passed." in result
+        assert "Project: Project1" in result
+        assert "Design: Design1" in result
+
+    def test_validate_design_failure_returns_log(self, mock_context):
+        """Validation failure should return AEDT validation details."""
+        from ansys.aedt.mcp.tools import validate_design
+
+        mock_app = MagicMock()
+        mock_app.project_name = "Project1"
+        mock_app.design_name = "Design1"
+
+        def write_validation_log(log_file):
+            Path(log_file).write_text("Error: Missing boundary condition", encoding="utf-8")
+            return 0
+
+        mock_app.validate_simple.side_effect = write_validation_log
+
+        with patch("ansys.aedt.core.get_pyaedt_app", return_value=mock_app):
+            result = validate_design(mock_context)
+
+        assert "Design validation failed." in result
+        assert "Details:" in result
+        assert "Error: Missing boundary condition" in result
+
+    def test_validate_design_no_connection(self, mock_context_no_desktop):
+        """Validation should require an AEDT connection."""
+        from ansys.aedt.mcp.tools import validate_design
+
+        result = validate_design(mock_context_no_desktop)
+        assert "No AEDT connection" in result
+
+
+@pytest.mark.unit
 class TestAnalyzeDesign:
     """Tests for analyze_design tool."""
 
@@ -1209,6 +1258,7 @@ async def test_tools_registered():
         "open_project",
         "save_project",
         "create_design",
+        "validate_design",
         "analyze_design",
         "export_results",
         "export_config",
@@ -1867,6 +1917,7 @@ class TestRequiresAEDTVisibility:
             "open_project",
             "save_project",
             "create_design",
+            "validate_design",
             "analyze_design",
             "export_results",
             "screenshot",

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -128,6 +128,13 @@ class TestToolsetsResource:
         assert "connected session has no open projects" in lifecycle_skill
         assert "call create_design with the matching app_type" in lifecycle_skill
 
+    def test_simulation_toolset_includes_design_validation(self):
+        simulation_tools = _TOOLSET_CATALOGUE["simulation"]["tools"]
+        simulation_skill = _TOOLSET_CATALOGUE["simulation"]["skill"]
+
+        assert "validate_design" in simulation_tools
+        assert "Use validate_design" in simulation_skill
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
@gmalinve: I implemented the design validation as a dedicated tool and wired it into both indexing and prompt behavior. Steps:
- Add a new validate_design MCP tool
- Reuse shared validation logic so behavior stays consistent
- Add the new tool to the tool index/catalogue (toolsets://definition)
- Update internal prompts to call validation programmatically for design-specific workflows
- Add/update tests for tool behavior, registration, tags, prompt text, and toolset indexing